### PR TITLE
feat: add qwickapps-dev-guide plugin with 3 guidance skills

### DIFF
--- a/plugins/qwickapps-dev-guide/.claude-plugin/plugin.json
+++ b/plugins/qwickapps-dev-guide/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "qwickapps-dev-guide",
+  "description": "QwickApps developer guidance skills. Teaches how to build apps using @qwickapps/cms (ServerQwickApp, BlockRenderer, FooterFromSettings), @qwickapps/server (createGateway, port scheme, control panel plugins), and @qwickapps/react-framework (QwickApp, navigation, theme variables). Use alongside qwickapps-ux-design for complete QwickApps development guidance.",
+  "author": {
+    "name": "QwickApps",
+    "email": "support@qwickapps.com"
+  },
+  "skills": [
+    {
+      "name": "build-with-cms",
+      "path": "skills/build-with-cms/SKILL.md"
+    },
+    {
+      "name": "build-with-server",
+      "path": "skills/build-with-server/SKILL.md"
+    },
+    {
+      "name": "build-frontend-app",
+      "path": "skills/build-frontend-app/SKILL.md"
+    }
+  ]
+}

--- a/plugins/qwickapps-dev-guide/skills/build-frontend-app/SKILL.md
+++ b/plugins/qwickapps-dev-guide/skills/build-frontend-app/SKILL.md
@@ -1,0 +1,361 @@
+---
+name: build-frontend-app
+description: >
+  Use when setting up the frontend application shell for any QwickApps product using @qwickapps/react-framework.
+  Covers: QwickApp wrapper (required for every app), navigation items (MenuItem format),
+  enableScaffolding (app bar + sidebar), theme CSS variables (--theme-*), and framework component imports.
+  Invoke before creating any layout component or app shell. Use alongside build-with-cms and qwickapps-ux-design.
+---
+
+# Building the Frontend App Shell with @qwickapps/react-framework
+
+This skill covers setting up the `QwickApp` wrapper and app shell. For UI components, also invoke
+`qwickapps-ux-design:frontend-design`. For CMS integration, also invoke `build-with-cms`.
+
+---
+
+## 1. QwickApp — Required Root Wrapper
+
+Every QwickApps frontend must be wrapped in `QwickApp`. This provides:
+- Theme system (light/dark/system, palette)
+- App context (`useQwickApp` hook)
+- Optional scaffolding (app bar + sidebar nav)
+- Routing integration
+
+**Import:**
+
+```typescript
+import { QwickApp } from '@qwickapps/react-framework';
+```
+
+### Full Props Interface
+
+```typescript
+interface QwickAppProps {
+  // App Identity
+  appName?: string;                    // Display name (used in title, app bar)
+  appId?: string | true | false;       // Storage key prefix for persisted state
+  appVersion?: string;                 // Version string
+
+  // Theme
+  defaultTheme?: 'light' | 'dark' | 'system';    // Default: 'system'
+  defaultPalette?: string;                         // Default palette name
+  showThemeSwitcher?: boolean;                     // Default: false
+  showPaletteSwitcher?: boolean;                   // Default: false
+
+  // Scaffolding (Nav)
+  enableScaffolding?: boolean;                     // Enable app bar + sidebar (default: false)
+  navigationItems?: MenuItem[];                    // Primary nav items
+  appBar?: ScaffoldProps['appBar'];                // App bar customization
+  showAppBar?: boolean;                            // Default: true
+  appBarHeight?: number;                           // Default: 64
+
+  // Callbacks
+  onLogoClick?: () => void;
+
+  // Content
+  children?: React.ReactNode;
+  className?: string;
+  footerContent?: React.ReactNode;
+
+  // Advanced
+  logo?: React.ReactNode;              // Custom logo component
+  config?: AppConfig;                  // Config instance (overrides individual props)
+}
+```
+
+---
+
+## 2. Navigation Items Format
+
+```typescript
+interface MenuItem {
+  label: string;          // Display text
+  route: string;          // URL path (e.g., '/', '/dashboard', '/repos')
+  icon?: string;          // Material icon name (e.g., 'home', 'search', 'settings')
+  children?: MenuItem[];  // Sub-menu items
+}
+```
+
+### Marketing Site Navigation
+
+```typescript
+const marketingNav: MenuItem[] = [
+  { label: 'Home', route: '/', icon: 'home' },
+  { label: 'Features', route: '/features', icon: 'star' },
+  { label: 'Pricing', route: '/pricing', icon: 'payments' },
+  { label: 'Sign In', route: '/auth/login', icon: 'login' },
+];
+```
+
+### Dashboard Navigation (authenticated area)
+
+```typescript
+const dashboardNav: MenuItem[] = [
+  { label: 'Dashboard', route: '/dashboard', icon: 'dashboard' },
+  { label: 'Repositories', route: '/repositories', icon: 'source' },
+  { label: 'Documents', route: '/documents', icon: 'description' },
+  { label: 'Query', route: '/query', icon: 'search' },
+  { label: 'Settings', route: '/settings', icon: 'settings' },
+];
+```
+
+### Nested Navigation
+
+```typescript
+const nav: MenuItem[] = [
+  {
+    label: 'Services',
+    route: '/services',
+    icon: 'build',
+    children: [
+      { label: 'Consulting', route: '/services/consulting' },
+      { label: 'Development', route: '/services/development' },
+    ],
+  },
+];
+```
+
+---
+
+## 3. Marketing Site App Shell Pattern
+
+For marketing/public pages (no auth required, no persistent nav scaffolding).
+Navigation is driven by CMS via `ServerQwickApp` — see `build-with-cms`.
+
+```tsx
+// src/components/MarketingClientApp.tsx
+'use client';
+
+import { QwickApp } from '@qwickapps/react-framework';
+
+interface MarketingClientAppProps {
+  children: React.ReactNode;
+  navigationItems?: MenuItem[];
+  theme?: 'light' | 'dark' | 'system';
+}
+
+export function MarketingClientApp({ children, navigationItems, theme = 'system' }: MarketingClientAppProps) {
+  return (
+    <QwickApp
+      appId="com.myapp.website"
+      appName="My App"
+      defaultTheme={theme}
+      enableScaffolding={true}
+      navigationItems={navigationItems}
+      showThemeSwitcher={false}
+    >
+      {children}
+    </QwickApp>
+  );
+}
+```
+
+---
+
+## 4. Dashboard App Shell Pattern
+
+For authenticated dashboard areas with sidebar navigation.
+
+```tsx
+// src/components/DashboardClientApp.tsx
+'use client';
+
+import { QwickApp } from '@qwickapps/react-framework';
+import type { MenuItem } from '@qwickapps/react-framework';
+
+const dashboardNav: MenuItem[] = [
+  { label: 'Dashboard', route: '/dashboard', icon: 'dashboard' },
+  { label: 'Repositories', route: '/repositories', icon: 'source' },
+  { label: 'Query', route: '/query', icon: 'search' },
+  { label: 'Settings', route: '/settings', icon: 'settings' },
+];
+
+export function DashboardClientApp({ children }: { children: React.ReactNode }) {
+  return (
+    <QwickApp
+      appId="com.myapp.dashboard"
+      appName="My App"
+      defaultTheme="dark"
+      enableScaffolding={true}
+      navigationItems={dashboardNav}
+      showThemeSwitcher={true}
+    >
+      {children}
+    </QwickApp>
+  );
+}
+```
+
+---
+
+## 5. App Bar Customization
+
+Customize the app bar with actions (buttons, icons) on the right side.
+
+```tsx
+<QwickApp
+  appName="My App"
+  enableScaffolding={true}
+  navigationItems={nav}
+  appBar={{
+    actions: (
+      <>
+        <IconButton sx={{ color: 'var(--theme-on-surface)' }}>
+          <NotificationsIcon />
+        </IconButton>
+        <Button variant="contained" href="/auth/login">Sign In</Button>
+      </>
+    ),
+  }}
+>
+  {children}
+</QwickApp>
+```
+
+---
+
+## 6. Theme CSS Variables
+
+All colors must use `--theme-*` CSS variables. Never use hex, rgba, or color strings directly.
+These variables are applied via `data-theme` and `data-palette` attributes on `<html>`.
+
+### Available Variables
+
+```css
+/* Primary Brand Colors */
+var(--theme-primary)              /* Main brand color */
+var(--theme-on-primary)           /* Text/icons on primary background */
+var(--theme-primary-container)    /* Lighter primary container */
+var(--theme-on-primary-container) /* Text on primary container */
+
+/* Secondary Colors */
+var(--theme-secondary)
+var(--theme-on-secondary)
+var(--theme-secondary-container)
+var(--theme-on-secondary-container)
+
+/* Surfaces */
+var(--theme-background)           /* Page background */
+var(--theme-on-background)        /* Text on page background */
+var(--theme-surface)              /* Card/panel background */
+var(--theme-on-surface)           /* Text on surface */
+var(--theme-surface-variant)      /* Alternate surface */
+var(--theme-surface-elevated)     /* Elevated surface (modals, dropdowns) */
+
+/* Borders */
+var(--theme-outline)              /* Default border color */
+var(--theme-border-main)          /* Main border */
+
+/* Feedback */
+var(--theme-error)
+var(--theme-on-error)
+var(--theme-success)
+var(--theme-warning)
+
+/* Text */
+var(--theme-text-secondary)       /* Secondary/muted text */
+```
+
+### Usage in sx Props
+
+```tsx
+// Correct — all via CSS variables
+<Box sx={{
+  backgroundColor: 'var(--theme-surface)',
+  color: 'var(--theme-on-surface)',
+  borderColor: 'var(--theme-outline)',
+  '&:hover': {
+    backgroundColor: 'var(--theme-surface-variant)',
+  },
+}}>
+  Content
+</Box>
+```
+
+---
+
+## 7. Framework Component Imports
+
+All UI components import from `@qwickapps/react-framework`:
+
+```typescript
+// Layout
+import { Section, GridLayout, GridCell, Page, HeroBlock } from '@qwickapps/react-framework';
+
+// Content
+import { Text, Button, FeatureCard, FeatureGrid, Markdown, Footer } from '@qwickapps/react-framework';
+
+// Commerce
+import { ProductCard } from '@qwickapps/react-framework';
+
+// Forms
+import { FormField, FormSelect, FormCheckbox, Captcha } from '@qwickapps/react-framework';
+
+// Utils
+import { iconMap } from '@qwickapps/react-framework';
+```
+
+Never import from `@mui/material` or `@mui/icons-material` — invoke `find-component` first.
+If a component is missing, invoke `extend-framework`.
+
+---
+
+## 8. useQwickApp Hook
+
+Access and update app config from any child component:
+
+```typescript
+import { useQwickApp } from '@qwickapps/react-framework';
+
+function MyComponent() {
+  const {
+    appName,
+    enableScaffolding,
+    navigationItems,
+    showAppBar,
+    updateConfig,    // Dynamically update app config
+  } = useQwickApp();
+
+  // Example: show/hide nav based on auth state
+  useEffect(() => {
+    if (isAuthenticated) {
+      updateConfig({ navigationItems: dashboardNav });
+    }
+  }, [isAuthenticated]);
+}
+```
+
+---
+
+## 9. Next.js Integration Pattern
+
+In a Next.js app with App Router, the `QwickApp` wrapper goes in the client layout:
+
+```tsx
+// app/(app)/layout.tsx (server component — uses ServerQwickApp from @qwickapps/cms)
+// The ServerQwickApp internally creates QwickApp via ClientSideQwickApp.
+// Do NOT create a separate QwickApp wrapper in the layout — ServerQwickApp handles it.
+```
+
+For dashboard routes that don't go through `ServerQwickApp` (auth-required areas):
+
+```tsx
+// app/(dashboard)/layout.tsx
+import { DashboardClientApp } from '@/components/DashboardClientApp';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  return <DashboardClientApp>{children}</DashboardClientApp>;
+}
+```
+
+---
+
+## 10. Common Mistakes
+
+- **Do not** nest `QwickApp` inside `QwickApp` — only one wrapper per route group.
+- **Do not** use `QwickApp` in server components (`'use server'` or `async function`). It is a client component.
+- **Do not** hardcode colors with hex or rgba. Use `var(--theme-*)` exclusively.
+- **Do not** import MUI components directly. Import from `@qwickapps/react-framework` or invoke `find-component`.
+- **Do not** set `enableScaffolding={false}` if you need the app bar — set it to `true` with your `navigationItems`.
+- **Do not** create a duplicate `QwickApp` wrapper when using `ServerQwickApp` from `@qwickapps/cms` — `ServerQwickApp` already creates the client-side wrapper internally.

--- a/plugins/qwickapps-dev-guide/skills/build-with-cms/SKILL.md
+++ b/plugins/qwickapps-dev-guide/skills/build-with-cms/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: build-with-cms
+description: >
+  Use when building any QwickApps product that integrates with Payload CMS via @qwickapps/cms.
+  Covers: ServerQwickApp (server-side settings + nav fetch), BlockRenderer (12 block types from CMS),
+  FooterFromSettings (auto-rendered footer), standard Payload collections and globals, and seed patterns.
+  Invoke before writing any app layout, page, or CMS seed script.
+---
+
+# Building with @qwickapps/cms
+
+This skill guides CMS-integrated app development using `@qwickapps/cms`. All patterns are verified
+from production clients (work-macha, faabzi). Read each section that applies to your task.
+
+---
+
+## 1. ServerQwickApp — App Layout
+
+`ServerQwickApp` is a server component that fetches navigation and all 4 CMS globals server-side,
+then passes them to `ClientSideQwickApp`. Use it as the root wrapper in `app/(app)/layout.tsx`.
+
+### Props
+
+```typescript
+import { ServerQwickApp } from '@qwickapps/cms/nextjs';
+import type { Config } from 'payload';
+
+interface ServerQwickAppProps {
+  children: ReactNode;
+  payloadConfig: Config;       // from configPromise (import configPromise from '@payload-config')
+  appBar?: {
+    actions?: ReactNode | (() => ReactNode);
+  };
+  providers?: React.ComponentType<{ children: ReactNode }>;
+}
+```
+
+### Standard Usage Pattern
+
+```tsx
+// app/(app)/layout.tsx
+import { ServerQwickApp } from '@qwickapps/cms/nextjs';
+import { FooterFromSettings } from '@qwickapps/cms/nextjs/client';
+import configPromise from '@payload-config';
+
+export default async function AppRouteLayout({ children }: { children: React.ReactNode }) {
+  const config = await configPromise;
+  return (
+    <ServerQwickApp payloadConfig={config}>
+      {children}
+      <FooterFromSettings />
+    </ServerQwickApp>
+  );
+}
+```
+
+### What ServerQwickApp Does Internally
+
+1. Fetches `navigation` collection (position: "main") for nav items
+2. Fetches all 4 globals: `SiteSettings`, `ThemeSettings`, `Integrations`, `AdvancedSettings`
+3. Handles Payload init errors gracefully (secret key issues, DB not ready)
+4. Falls back to default navigation if CMS data unavailable
+5. Passes merged settings to `ClientSideQwickApp` via context
+
+### With Custom App Bar Actions
+
+```tsx
+<ServerQwickApp
+  payloadConfig={config}
+  appBar={{
+    actions: (
+      <>
+        <Button variant="outlined" href="/auth/login">Sign In</Button>
+        <Button variant="contained" href="/auth/register">Get Started</Button>
+      </>
+    )
+  }}
+>
+  {children}
+  <FooterFromSettings />
+</ServerQwickApp>
+```
+
+---
+
+## 2. BlockRenderer — CMS-Driven Pages
+
+`BlockRenderer` renders an array of Payload CMS blocks as QwickApps Framework components.
+Use it in page components to render the `layout` field of `Pages` collection documents.
+
+### Props
+
+```typescript
+import { BlockRenderer } from '@qwickapps/cms/nextjs/client';
+
+interface BlockRendererProps {
+  blocks?: BlockData[];    // layout field from Payload Pages document
+  className?: string;
+}
+```
+
+### Standard Page Pattern
+
+```tsx
+// app/(app)/[...slug]/page.tsx
+import { getPayload } from 'payload';
+import configPromise from '@payload-config';
+import { BlockRenderer } from '@qwickapps/cms/nextjs/client';
+
+export default async function Page({ params }: { params: { slug: string[] } }) {
+  const payload = await getPayload({ config: await configPromise });
+  const slug = params.slug?.join('/') ?? 'home';
+
+  const { docs } = await payload.find({
+    collection: 'pages',
+    where: { slug: { equals: slug }, status: { equals: 'published' } },
+    limit: 1,
+  });
+
+  if (!docs[0]) notFound();
+
+  return <BlockRenderer blocks={docs[0].layout} />;
+}
+```
+
+### Supported Block Types (12 total)
+
+All blocks support: `padding`, `marginTop`, `marginBottom`, `background`, `color`,
+`backgroundImage`, `backgroundGradient` (ViewSchema props).
+
+| blockType | Key Fields | Renders As |
+|-----------|-----------|-----------|
+| `hero` | title, subtitle, backgroundImage, backgroundGradient, blockHeight, textAlign, actions[] | HeroBlock |
+| `textSection` | heading, content (Lexical), padding, background, textAlign, maxWidth | Section + Text |
+| `featureGrid` | heading, features[], columns, spacing, padding, background | GridLayout + FeatureCard[] |
+| `ctaSection` | heading, description, buttons[], padding, background, textAlign | Section + Button[] |
+| `image` | image, alt, caption, size | Image |
+| `spacer` | height | div |
+| `code` | code, language, title, showCopy, showLineNumbers, wrapLines | Paper + code block |
+| `productGrid` | heading, products[], variant, columns, spacing, padding, background | GridLayout + ProductCard[] |
+| `accordion` | heading, items[], allowMultiple, variant, padding | Section + AccordionItem[] |
+| `cardGrid` | heading, cards[], columns, spacing, cardVariant, padding, background | GridLayout + Card[] |
+| `form` | form (relationship), overrideHeading, overrideDescription, padding | FormBlockComponent |
+| `markdown` | heading, content (string), textAlign, maxWidth, padding | Section + Markdown |
+
+### Seed Data Examples
+
+```javascript
+// Seed: home page with blocks
+await payload.create({
+  collection: 'pages',
+  data: {
+    title: 'Home',
+    slug: 'home',
+    status: 'published',
+    layout: [
+      {
+        blockType: 'hero',
+        title: 'Welcome to Our App',
+        subtitle: 'AI-powered solutions for modern teams',
+        blockHeight: 'large',
+        backgroundGradient: 'linear-gradient(135deg, var(--theme-primary) 0%, var(--theme-secondary) 100%)',
+        actions: [
+          { label: 'Get Started', href: '/auth/register', variant: 'contained' },
+          { label: 'Learn More', href: '/features', variant: 'outlined' },
+        ],
+      },
+      {
+        blockType: 'featureGrid',
+        heading: 'Why Choose Us',
+        columns: 2,
+        features: [
+          { icon: 'search', title: 'Semantic Search', description: 'Find anything instantly.' },
+          { icon: 'auto_awesome', title: 'AI Analysis', description: 'Powered by Claude.' },
+        ],
+      },
+      {
+        blockType: 'ctaSection',
+        heading: 'Ready to get started?',
+        buttons: [{ label: 'Start Free', href: '/auth/register', variant: 'contained' }],
+      },
+    ],
+  },
+});
+```
+
+---
+
+## 3. FooterFromSettings — Auto-Rendered Footer
+
+`FooterFromSettings` is a client component with no props. It fetches the `footer` collection
+(position: "main") and renders with copyright from `SiteSettings`.
+
+### Usage
+
+```tsx
+// Already included in the ServerQwickApp layout pattern above.
+// Import path:
+import { FooterFromSettings } from '@qwickapps/cms/nextjs/client';
+```
+
+### What FooterFromSettings Does
+
+- Fetches footer from `footer` collection (position: "main")
+- Replaces `{year}` → current year, `{siteName}` → SiteSettings.siteName
+- Shows "Powered by QwickPress" and "Payload CMS" links on right side
+- Renders `Footer` component with sections, orientation, variant from CMS data
+
+### Footer Seed Pattern
+
+```javascript
+// scripts/seeds/002.seed-footer.mjs
+await payload.create({
+  collection: 'footer',
+  data: {
+    name: 'Main Footer',
+    position: 'main',
+    orientation: 'horizontal',
+    showDivider: true,
+    sections: [
+      {
+        title: 'PRODUCT',
+        items: [
+          { label: 'Home', route: '/' },
+          { label: 'Features', route: '/features' },
+          { label: 'Pricing', route: '/pricing' },
+        ],
+      },
+      {
+        title: 'COMPANY',
+        items: [
+          { label: 'About', route: '/about' },
+          { label: 'Contact', route: '/contact' },
+        ],
+      },
+    ],
+  },
+});
+```
+
+---
+
+## 4. Navigation Seed Pattern
+
+```javascript
+// scripts/seeds/001.seed-navigation.mjs
+await payload.create({
+  collection: 'navigation',
+  data: {
+    name: 'Main Navigation',
+    position: 'main',
+    items: [
+      { label: 'Home', route: '/', icon: 'home' },
+      { label: 'Features', route: '/features', icon: 'star' },
+      { label: 'Pricing', route: '/pricing', icon: 'payments' },
+      { label: 'Sign In', route: '/auth/login', icon: 'login' },
+    ],
+  },
+});
+```
+
+---
+
+## 5. Standard Collections
+
+Import individually from `@qwickapps/cms/collections` or use the combined export.
+
+| Collection | Slug | Key Fields |
+|------------|------|-----------|
+| `Navigation` | `navigation` | name, position, items[] |
+| `Pages` | `pages` | title, slug, status, layout (blocks) |
+| `Footer` | `footer` | name, position, orientation, sections[], showDivider |
+| `Media` | `media` | filename, alt, url |
+| `Users` | `users` | email, role, name |
+| `Forms` | `forms` | title, fields[], confirmationType |
+| `FormSubmissions` | `form-submissions` | form (rel), submissionData[] |
+| `Posts` | `posts` | title, slug, status, content (Lexical) |
+| `Products` | `products` | name, slug, price, images[], description |
+| `HeroBlocks` | `hero-blocks` | title, subtitle, image, actions[] |
+| `HeroSlideshows` | `hero-slideshows` | name, position, slides[] |
+| `Features` | `features` | name, icon, title, description |
+| `Automations` | `automations` | name, trigger, actions[] |
+
+### Adding to payload.config.ts
+
+```typescript
+import {
+  Navigation,
+  Pages,
+  Footer,
+  Media,
+  Users,
+  Forms,
+  FormSubmissions,
+} from '@qwickapps/cms/collections';
+
+export default buildConfig({
+  collections: [Navigation, Pages, Footer, Media, Users, Forms, FormSubmissions],
+  // ... rest of config
+});
+```
+
+---
+
+## 6. Standard Globals
+
+| Global | Slug | Key Fields |
+|--------|------|-----------|
+| `SiteSettings` | `site-settings` | siteName, description, logo, favicon, copyrightText, contactEmail, socialMedia |
+| `ThemeSettings` | `theme-settings` | defaultTheme (light/dark/system), defaultPalette, showThemeSwitcher, showPaletteSwitcher |
+| `Integrations` | `integrations` | googleAnalytics, gtm, facebookPixel, captcha, emailSettings |
+| `AdvancedSettings` | `advanced-settings` | seo, customScripts, maintenanceMode |
+
+### SiteSettings Seed
+
+```javascript
+// scripts/seeds/000.seed-site-settings.mjs
+await payload.updateGlobal({
+  slug: 'site-settings',
+  data: {
+    siteName: 'My App',
+    description: 'AI-powered solutions for modern teams.',
+    copyrightText: '© {year} My App. All rights reserved.',
+    contactEmail: 'hello@myapp.com',
+  },
+});
+```
+
+### ThemeSettings Seed
+
+```javascript
+await payload.updateGlobal({
+  slug: 'theme-settings',
+  data: {
+    defaultTheme: 'dark',
+    defaultPalette: 'primary',
+    showThemeSwitcher: false,
+    showPaletteSwitcher: false,
+  },
+});
+```
+
+---
+
+## 7. Seed Script Boilerplate
+
+All seed scripts follow this pattern:
+
+```javascript
+// scripts/seeds/NNN.seed-description.mjs
+import { getPayload } from 'payload';
+import { importConfig } from 'payload/node';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const configPath = resolve(__dirname, '../../payload.config.ts');
+
+const config = await importConfig(configPath);
+const payload = await getPayload({ config });
+
+try {
+  // Your seed logic here
+  await payload.create({ collection: 'pages', data: { ... } });
+  await payload.updateGlobal({ slug: 'site-settings', data: { ... } });
+  console.log('Seed complete');
+} catch (error) {
+  console.error('Seed failed:', error);
+  process.exit(1);
+} finally {
+  await payload.db?.destroy?.();
+  process.exit(0);
+}
+```
+
+---
+
+## 8. Common Mistakes
+
+- **Do not** call `ServerQwickApp` from a client component (`'use client'`). It is a server component only.
+- **Do not** import `FooterFromSettings` from `@qwickapps/cms/nextjs` (server path). Use `@qwickapps/cms/nextjs/client`.
+- **Do not** import `BlockRenderer` from `@qwickapps/cms/nextjs` (server path). Use `@qwickapps/cms/nextjs/client`.
+- **Do not** hard-code nav items in the app — seed the `navigation` collection so `ServerQwickApp` picks them up automatically.
+- **Do not** skip the `status: 'published'` filter on pages queries — draft pages should not render.

--- a/plugins/qwickapps-dev-guide/skills/build-with-server/SKILL.md
+++ b/plugins/qwickapps-dev-guide/skills/build-with-server/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: build-with-server
+description: >
+  Use when building or modifying the gateway layer for any QwickApps product using @qwickapps/server.
+  Covers: createGateway (config interface, port scheme), MountedAppConfig (proxy + static sources),
+  controlPanel configuration, available built-in plugins, WebSocket proxying, and guard patterns.
+  Invoke before writing any gateway.ts or server entry point.
+---
+
+# Building with @qwickapps/server
+
+This skill guides gateway and server development using `@qwickapps/server`. All APIs are verified
+from production clients (authkeaper, work-macha). Read the section that applies to your task.
+
+---
+
+## 1. Port Scheme
+
+Every QwickApps product follows a consistent port layout:
+
+```
+PORT        → Gateway (public-facing, proxies everything)
+PORT + 1    → Control Panel internal HTTP server
+PORT + 2+   → App services (Payload, Next.js, etc.)
+```
+
+**Example with PORT=3400:**
+```
+3400 → Gateway (createGateway listens here)
+3401 → Control Panel internal server
+3402 → Payload/Next.js application
+```
+
+**Required env vars in `.env.local`:**
+
+```env
+PORT=3400
+PAYLOAD_SERVICE_URL=http://localhost:3402
+DATABASE_URI=postgresql://user:pass@localhost:5432/mydb
+PAYLOAD_SECRET=your-secret-key
+```
+
+Next.js must use `PORT + 2` to avoid conflict with gateway's internal control panel server (PORT + 1).
+
+---
+
+## 2. createGateway — Full Interface
+
+```typescript
+import { createGateway } from '@qwickapps/server';
+
+const gateway = createGateway({
+  port: Number(process.env.PORT) || 3000,    // Gateway port (public-facing)
+  productName: 'My App',                      // Display name in control panel
+  version: process.env.npm_package_version,   // Version string (optional)
+  logoIconUrl: '/cpanel/logo.svg',            // Logo shown in control panel header
+
+  // Proxy routes to backend services
+  apps: [...],
+
+  // Built-in control panel
+  controlPanel: { ... },
+
+  // Optional: what to show at root path (/) when no app is mounted there
+  frontendApp: { ... },
+});
+
+await gateway.start();
+```
+
+**GatewayInstance returned:**
+```typescript
+{
+  app: Application;       // Express app
+  server: Server | null;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  port: number;
+}
+```
+
+---
+
+## 3. apps[] — Mounted App Configuration
+
+Each entry in `apps` mounts a service at a path. Two source types: `proxy` and `static`.
+
+### Proxy Source (most common)
+
+```typescript
+apps: [
+  {
+    path: '/api',
+    name: 'API Service',
+    source: {
+      type: 'proxy',
+      target: `http://localhost:${payloadPort}`,  // PORT + 2
+      ws: true,    // Enable WebSocket proxy (needed for HMR in dev)
+    },
+    // stripPrefix: true (default) — strips /api before forwarding
+  },
+]
+```
+
+### Static Source
+
+```typescript
+apps: [
+  {
+    path: '/docs',
+    name: 'Documentation',
+    source: {
+      type: 'static',
+      directory: join(__dirname, '../dist-docs'),
+      spa: true,   // Serve index.html for all paths (SPA mode)
+    },
+  },
+]
+```
+
+### Full MountedAppConfig Interface
+
+```typescript
+interface MountedAppConfig {
+  path: string;             // Mount path (e.g., '/api', '/admin', '/')
+  name?: string;            // Display name in control panel
+
+  source:
+    | { type: 'proxy'; target: string; ws?: boolean }
+    | { type: 'static'; directory: string; spa?: boolean };
+
+  stripPrefix?: boolean;    // Strip path prefix when proxying (default: true)
+  guard?: GuardConfig;      // Route-level auth guard
+  maintenance?: MaintenanceConfig;
+  fallback?: FallbackConfig;
+}
+```
+
+---
+
+## 4. controlPanel — Control Panel Configuration
+
+```typescript
+controlPanel: {
+  enabled: true,                  // Default: true
+  path: '/cpanel',                // Mount path for control panel UI
+  port: Number(process.env.PORT) + 1,  // Internal server port (PORT + 1)
+
+  // Auth guard for control panel
+  guard: {
+    type: 'basic',
+    username: process.env.ADMIN_USERNAME || 'admin',
+    password: process.env.ADMIN_PASSWORD,
+    realm: 'My App Control Panel',
+    excludePaths: ['/health', '/api', '/assets'],
+  },
+
+  // Built-in plugins (monitoring, management)
+  plugins: [
+    { plugin: createHealthPlugin() },
+    { plugin: createDiagnosticsPlugin() },
+    { plugin: createPostgresPlugin({
+      connectionString: process.env.DATABASE_URI,
+    })},
+    { plugin: createLogsPlugin() },
+    { plugin: createConfigPlugin({
+      config: { /* key-value pairs to display */ },
+      maskKeys: ['ADMIN_PASSWORD', 'PAYLOAD_SECRET', 'DATABASE_URI'],
+    })},
+  ],
+
+  // Quick links shown in control panel sidebar
+  links: [
+    { label: 'App Home', url: '/' },
+    { label: 'API Health', url: '/api/health' },
+    { label: 'Payload Admin', url: '/admin' },
+  ],
+}
+```
+
+---
+
+## 5. Available Built-in Plugins
+
+Import from `@qwickapps/server`:
+
+| Plugin | Import | Purpose |
+|--------|--------|---------|
+| `createHealthPlugin` | `@qwickapps/server` | Health check dashboard |
+| `createDiagnosticsPlugin` | `@qwickapps/server` | System diagnostics |
+| `createConfigPlugin` | `@qwickapps/server` | Config viewer with masking |
+| `createLogsPlugin` | `@qwickapps/server` | Log viewer |
+| `createPostgresPlugin` | `@qwickapps/server` | PostgreSQL connection monitor |
+| `createCachePlugin` | `@qwickapps/server` | Redis/cache connection monitor |
+| `createRateLimitPluginFromEnv` | `@qwickapps/server` | Rate limiting |
+| `createUsersPlugin` | `@qwickapps/server` | User management |
+| `createBansPlugin` | `@qwickapps/server` | User ban management |
+| `createEntitlementsPlugin` | `@qwickapps/server` | Entitlements system |
+
+---
+
+## 6. Complete gateway.ts Example
+
+```typescript
+// gateway.ts
+import { createGateway, createHealthPlugin, createPostgresPlugin,
+         createLogsPlugin, createConfigPlugin, createDiagnosticsPlugin } from '@qwickapps/server';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const gatewayPort = Number(process.env.PORT) || 3400;
+const appPort = gatewayPort + 2;     // Next.js/Payload
+
+const gateway = createGateway({
+  port: gatewayPort,
+  productName: 'My App',
+  version: process.env.npm_package_version,
+  logoIconUrl: '/cpanel/logo.svg',
+
+  apps: [
+    {
+      path: '/',                     // Proxy everything at root to Next.js
+      name: 'Next.js App',
+      source: {
+        type: 'proxy',
+        target: `http://localhost:${appPort}`,
+        ws: true,
+      },
+    },
+  ],
+
+  controlPanel: {
+    enabled: true,
+    path: '/cpanel',
+    port: gatewayPort + 1,
+
+    guard: {
+      type: 'basic',
+      username: process.env.ADMIN_USERNAME || 'admin',
+      password: process.env.ADMIN_PASSWORD || 'changeme',
+      realm: 'My App Control Panel',
+      excludePaths: ['/health', '/_next', '/api', '/favicon.ico'],
+    },
+
+    plugins: [
+      { plugin: createHealthPlugin() },
+      { plugin: createDiagnosticsPlugin() },
+      { plugin: createPostgresPlugin({ connectionString: process.env.DATABASE_URI }) },
+      { plugin: createLogsPlugin() },
+      { plugin: createConfigPlugin({
+        config: {
+          PORT: process.env.PORT,
+          NODE_ENV: process.env.NODE_ENV,
+          APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+        },
+        maskKeys: ['DATABASE_URI', 'PAYLOAD_SECRET', 'ADMIN_PASSWORD'],
+      })},
+    ],
+
+    links: [
+      { label: 'App', url: '/' },
+      { label: 'Payload Admin', url: '/admin' },
+    ],
+  },
+});
+
+gateway.start().then(() => {
+  console.log(`Gateway running on port ${gatewayPort}`);
+});
+```
+
+---
+
+## 7. package.json Scripts Pattern
+
+```json
+{
+  "scripts": {
+    "dev:local": "concurrently \"next dev -p $((PORT+2))\" \"tsx watch gateway.ts\"",
+    "dev:local:nobuild": "concurrently \"next dev -p $((PORT+2)) --no-turbo\" \"tsx watch gateway.ts\"",
+    "start": "concurrently \"next start -p $((PORT+2))\" \"node dist/gateway.js\"",
+    "build": "next build && tsc -p tsconfig.gateway.json"
+  }
+}
+```
+
+---
+
+## 8. WebSocket Proxy for Next.js HMR
+
+When developing with Next.js, HMR requires WebSocket proxy support. Set `ws: true` on the app
+that proxies to Next.js. This is handled automatically in `createGateway`.
+
+```typescript
+source: {
+  type: 'proxy',
+  target: `http://localhost:${appPort}`,
+  ws: true,    // REQUIRED for Next.js HMR to work through the gateway
+}
+```
+
+---
+
+## 9. Route Guards
+
+Guards protect specific mounted paths. Apply at `controlPanel.guard` or `apps[].guard`.
+
+```typescript
+guard: {
+  type: 'basic',                          // HTTP Basic Auth
+  username: process.env.ADMIN_USERNAME,
+  password: process.env.ADMIN_PASSWORD,
+  realm: 'Protected Area',
+  excludePaths: ['/health', '/api/public'], // Paths that bypass the guard
+}
+```
+
+---
+
+## 10. Common Mistakes
+
+- **Do not** use PORT directly for Payload/Next.js — it conflicts with the gateway. Always use `PORT + 2`.
+- **Do not** expose the control panel port (PORT + 1) externally — it is an internal server.
+- **Do not** set `stripPrefix: false` on proxied apps unless the target service expects the full path.
+- **Do not** start Next.js and gateway on the same port — the gateway must be on PORT, Next.js on PORT+2.
+- **Do not** skip `ws: true` on the Next.js proxy during development — HMR will fail.


### PR DESCRIPTION
## Summary

- Adds `qwickapps-dev-guide` plugin with 3 developer guidance skills
- `build-with-cms`: ServerQwickApp, BlockRenderer (12 block types), FooterFromSettings, standard collections/globals, seed patterns
- `build-with-server`: createGateway, port scheme (PORT/PORT+1/PORT+2), MountedAppConfig, controlPanel plugins, WebSocket proxy
- `build-frontend-app`: QwickApp wrapper, navigation items (MenuItem), enableScaffolding, theme CSS variables, framework imports

All APIs verified from production client source code (work-macha, authkeaper).

## Test plan

- [ ] Install plugin locally and verify all 3 skills are invocable
- [ ] Invoke each skill and confirm content is accurate against actual package APIs