### PR TITLE
fix: align plugin manifests with Claude Code spec

### DIFF
--- a/plugins/qwickapps-dev-guide/.claude-plugin/plugin.json
+++ b/plugins/qwickapps-dev-guide/.claude-plugin/plugin.json
@@ -1,22 +1,16 @@
 {
   "name": "qwickapps-dev-guide",
+  "version": "1.0.0",
   "description": "QwickApps developer guidance skills. Teaches how to build apps using @qwickapps/cms (ServerQwickApp, BlockRenderer, FooterFromSettings), @qwickapps/server (createGateway, port scheme, control panel plugins), and @qwickapps/react-framework (QwickApp, navigation, theme variables). Use alongside qwickapps-ux-design for complete QwickApps development guidance.",
   "author": {
     "name": "QwickApps",
     "email": "support@qwickapps.com"
   },
-  "skills": [
-    {
-      "name": "build-with-cms",
-      "path": "skills/build-with-cms/SKILL.md"
-    },
-    {
-      "name": "build-with-server",
-      "path": "skills/build-with-server/SKILL.md"
-    },
-    {
-      "name": "build-frontend-app",
-      "path": "skills/build-frontend-app/SKILL.md"
-    }
+  "keywords": [
+    "qwickapps",
+    "cms",
+    "server",
+    "react-framework",
+    "developer-guide"
   ]
 }

--- a/plugins/qwickapps-ux-design/.claude-plugin/plugin.json
+++ b/plugins/qwickapps-ux-design/.claude-plugin/plugin.json
@@ -1,39 +1,17 @@
 {
   "name": "qwickapps-ux-design",
+  "version": "1.0.0",
   "description": "QwickApps UX design system enforcement. Replaces frontend-design with framework-aware version. Enforces @qwickapps/react-framework components and --theme-* CSS variables. Creative freedom is preserved — missing components trigger framework extension, not workarounds.",
   "author": {
     "name": "QwickApps",
     "email": "support@qwickapps.com"
   },
-  "skills": [
-    {
-      "name": "frontend-design",
-      "path": "skills/frontend-design/SKILL.md"
-    },
-    {
-      "name": "find-component",
-      "path": "skills/find-component/SKILL.md"
-    },
-    {
-      "name": "extend-framework",
-      "path": "skills/extend-framework/SKILL.md"
-    }
+  "keywords": [
+    "qwickapps",
+    "ux-design",
+    "react-framework",
+    "theme-variables",
+    "component-enforcement"
   ],
-  "hooks": [
-    {
-      "event": "PreToolUse",
-      "tool": "Edit",
-      "path": "hooks/enforce-framework-usage.sh"
-    },
-    {
-      "event": "PreToolUse",
-      "tool": "Write",
-      "path": "hooks/enforce-framework-usage.sh"
-    },
-    {
-      "event": "PreToolUse",
-      "tool": "MultiEdit",
-      "path": "hooks/enforce-framework-usage.sh"
-    }
-  ]
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/qwickapps-ux-design/hooks/hooks.json
+++ b/plugins/qwickapps-ux-design/hooks/hooks.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-framework-usage.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-framework-usage.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-framework-usage.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Removed invalid `skills` arrays from qwickapps-dev-guide and qwickapps-ux-design plugin.json (skills are auto-discovered from `./skills/` directory per spec)
- Converted qwickapps-ux-design hooks from non-standard array format (`[{event, tool, path}]`) to proper `hooks.json` file reference
- Added `version` and `keywords` fields to both plugins

## Root Cause

The two plugins used non-standard plugin.json fields that are not part of the Claude Code plugin manifest specification:
1. `skills` array - not a valid manifest field; skills are auto-discovered from `./skills/` directory
2. `hooks` as `[{event, tool, path}]` array - not a valid format; must be either a file path string or inline config object

This caused "Installed 1 of 3 plugins. Failed: qwickapps-dev-guide, qwickapps-ux-design" while qwickapps-sdlc (which already used auto-discovery) installed successfully.

## Evidence

- All 17 official Anthropic plugins use auto-discovery (no skills/hooks declared in plugin.json)
- Plugin manifest reference (`plugin-dev` plugin, `manifest-reference.md`) documents only `commands`, `agents`, `hooks` (string or object), and `mcpServers` as component path fields - no `skills` field exists
- Debug logs showed persistent `Marketplace directory not found` errors for the old marketplace reference

## Test plan

- [ ] Merge this PR
- [ ] Update marketplace in Claude Code (`/plugins` > update)
- [ ] Reinstall qwickapps-dev-guide and qwickapps-ux-design
- [ ] Verify all 3 plugins load and skills appear in skill list
- [ ] Verify qwickapps-ux-design hooks fire on Edit/Write/MultiEdit of .tsx files

Generated with [Claude Code](https://claude.com/claude-code)