### PR TITLE
fix: remove duplicate hooks reference from ux-design manifest

### DIFF
--- a/plugins/qwickapps-ux-design/.claude-plugin/plugin.json
+++ b/plugins/qwickapps-ux-design/.claude-plugin/plugin.json
@@ -12,6 +12,5 @@
     "react-framework",
     "theme-variables",
     "component-enforcement"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }


### PR DESCRIPTION
## Summary

- Removed `"hooks": "./hooks/hooks.json"` from qwickapps-ux-design plugin.json

## Root Cause

`hooks/hooks.json` is auto-discovered by Claude Code (it's the default path). Declaring it explicitly in the manifest causes:

```
Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file
```

## Test plan

- [ ] Merge, update marketplace, restart Claude Code
- [ ] Verify no hooks loading error on startup
- [ ] Verify enforce-framework-usage hook fires on Edit/Write of .tsx files

Generated with [Claude Code](https://claude.com/claude-code)