### PR TITLE
feat: add deploy plugin with /setup_workflow command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,12 @@
       "description": "Complete software development lifecycle management. Issue-driven workflows, quality gates, agent personas, and engineering discipline skills. Replaces the superpowers plugin and the ai-sdlc-workflows Claude commands.",
       "source": "./plugins/qwickapps-sdlc",
       "category": "development"
+    },
+    {
+      "name": "deploy",
+      "description": "Deployment workflow generator for CapRover apps with QwickWay gateway. Generates GitHub Actions workflows, provides battle-tested deployment scripts, and troubleshooting guidance.",
+      "source": "./plugins/deploy",
+      "category": "devops"
     }
   ]
 }

--- a/plugins/deploy/.claude-plugin/plugin.json
+++ b/plugins/deploy/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "deploy",
+  "version": "1.0.0",
+  "description": "Deployment workflow generator for CapRover apps with QwickWay gateway. Provides /setup_workflow to generate correct GitHub Actions workflows, battle-tested deployment scripts, and troubleshooting guidance. Fixes common deployment pitfalls: wrong API endpoints, silent health check failures, missing gateway provisioning.",
+  "author": {
+    "name": "QwickApps",
+    "email": "support@qwickapps.com"
+  },
+  "keywords": [
+    "deploy",
+    "caprover",
+    "qwickway",
+    "github-actions",
+    "ghcr",
+    "docker",
+    "ci-cd"
+  ]
+}

--- a/plugins/deploy/README.md
+++ b/plugins/deploy/README.md
@@ -1,0 +1,113 @@
+# Deploy Plugin
+
+Deployment workflow generator for CapRover apps with QwickWay gateway support.
+
+## What It Does
+
+Generates correct GitHub Actions deployment workflows that fix common pitfalls found in hand-written workflows:
+
+| Bug | Symptom | Fix |
+|-----|---------|-----|
+| Wrong API for app creation | 404 or silent failure | Uses `/api/v2/user/apps/appDefinitions/register` |
+| Health check exits 0 on failure | Deploy reports success, app is down | `validate-deployment-health.sh` exits 1 on failure |
+| Errors piped to /dev/null | No error output | All API responses checked and logged |
+| No QwickWay gateway | Custom domain returns 404 | `setup-qwickway-route.sh` provisions gateway |
+| Missing environments | Only dev or only prod works | All 3 environments (prod, uat, dev) supported |
+
+## Quick Start
+
+```
+/setup_workflow
+```
+
+The command detects your repo type (standalone or monorepo) and walks you through configuration.
+
+## Architecture
+
+```
+route.qwickforge.com (QwickWay gateways)
+  |
+  |  TARGET_APP = https://<app>.app.qwickforge.com (external URL)
+  v
+app.qwickforge.com (prod/uat apps)
+dev.qwickforge.com (dev apps)
+```
+
+- **route.qwickforge.com**: Public-facing QwickWay gateway apps (separate CapRover server)
+- **app.qwickforge.com** (OCI_MAIN): Production and UAT apps
+- **dev.qwickforge.com** (OCI_DEV): Development apps (per-commit)
+- Gateway uses external URLs because apps and gateways are on different Docker swarms
+
+### App Naming
+
+| Env | App (app/dev.qwickforge) | Gateway (route.qwickforge) | Domain |
+|-----|--------------------------|---------------------------|--------|
+| prod | `<NAME>` | `<NAME>` | example.com |
+| uat | `<NAME>-uat` | `<NAME>-uat` | uat.example.com |
+| dev | `<NAME>-<sha>` (per commit) | `<NAME>-dev` (latest) | dev.example.com |
+
+## Scripts
+
+All scripts are self-contained bash scripts with `--flag` interfaces. They use `jq` for JSON, retry with exponential backoff on CapRover busy errors, and validate all API responses.
+
+| Script | Source | Description |
+|--------|--------|-------------|
+| `configure-caprover-app.sh` | Adapted from qwickapps | Provisions app, sets config, env vars (with diff comparison) |
+| `deploy-from-ghcr.sh` | Copied from qwickapps | Deploys Docker image from GHCR to CapRover |
+| `validate-deployment-health.sh` | Copied from qwickapps | HTTP check + log scan + container status |
+| `setup-ghcr-package.sh` | Copied from qwickapps | Configures GHCR package permissions |
+| `setup-qwickway-route.sh` | New | Provisions QwickWay gateway on route CapRover |
+| `cleanup-dev-builds.sh` | New | Keeps last N dev builds, deletes older ones |
+
+## Workflow Templates
+
+### `deploy-standalone.yml`
+
+For standalone repos (single app, own Dockerfile). Uses `ubuntu-latest` runner.
+
+**Jobs:** build -> deploy-app -> deploy-gateway -> cleanup-dev (dev only)
+
+### `deploy-monorepo-product.yml`
+
+For qwickapps monorepo products. Uses `self-hosted` runner with `zsh` shell.
+
+**Jobs:** build (with build-workspace-package.sh) -> deploy-app -> deploy-gateway -> cleanup-dev
+
+## Required GitHub Secrets
+
+| Secret | Used For | Environment |
+|--------|----------|-------------|
+| `CAPROVER_URL` | OCI_MAIN CapRover API | prod, uat |
+| `CAPROVER_PASSWORD` | OCI_MAIN auth | prod, uat |
+| `OCI_DEV_CAPROVER_URL` | OCI_DEV CapRover API | dev |
+| `OCI_DEV_CAPROVER_PASSWORD` | OCI_DEV auth | dev |
+| `ROUTE_CAPROVER_URL` | Route CapRover API | all |
+| `ROUTE_CAPROVER_PASSWORD` | Route CapRover auth | all |
+| `GHCR_PULL_TOKEN` | CapRover pulls from GHCR | all |
+
+## Skills
+
+- **provisioning**: CapRover + QwickWay provisioning guidance
+- **troubleshooting**: Deployment debugging (common errors, log analysis, rollback)
+
+## Plugin Structure
+
+```
+plugins/deploy/
+  .claude-plugin/plugin.json
+  commands/setup-workflow.md
+  skills/
+    provisioning/SKILL.md
+    troubleshooting/SKILL.md
+  scripts/
+    configure-caprover-app.sh
+    deploy-from-ghcr.sh
+    validate-deployment-health.sh
+    setup-ghcr-package.sh
+    setup-qwickway-route.sh
+    cleanup-dev-builds.sh
+  templates/
+    deploy-standalone.yml
+    deploy-monorepo-product.yml
+  README.md
+```

--- a/plugins/deploy/commands/setup-workflow.md
+++ b/plugins/deploy/commands/setup-workflow.md
@@ -1,0 +1,148 @@
+---
+name: setup_workflow
+description: Generate deployment workflow for any repo. Detects repo type (standalone vs monorepo), collects configuration, generates GitHub Actions workflow and deployment scripts.
+---
+
+The /setup_workflow command generates a complete GitHub Actions deployment workflow for the current repository.
+
+## Phase 1: Detect Repo Type
+
+Inspect the repository to determine its structure before asking the user any questions.
+
+1. Read `package.json` in the current directory. If it has a `workspaces` field, the repo is a monorepo. Otherwise it is standalone.
+2. Glob for `.github/workflows/deploy*.yml`. If any match:
+   - Warn the user: "A deployment workflow already exists at `<path>`. Overwrite it or create a new file alongside it?"
+   - Use AskUserQuestion to ask: "overwrite" or "create alongside"
+   - If "create alongside", the generated file will be named to avoid the conflict.
+3. Record the repo type and the existing-workflow decision before proceeding.
+
+## Phase 2: Collect Configuration
+
+Use AskUserQuestion to collect all required values. Ask all questions in a single call where possible. Do not guess values; ask explicitly.
+
+### Questions for all repos
+
+1. App name — suggest the directory name of the current repo as the default. Example: "What is the app name? (default: my-app)"
+2. Environments to deploy — multi-select: prod, uat, dev. Default: all three. Example: "Which environments should the workflow deploy to? (prod, uat, dev — default: all)"
+3. Container port — the port the app listens on inside the container. Default: 3000.
+4. Health check path — the HTTP path used for health checks. Default: /health.
+5. GitHub owner for GHCR — the GitHub organization or user that owns the container registry. Default: qwickapps.
+6. For each selected environment, ask for its domain:
+   - If prod selected: "Production domain (e.g., myapp.example.com)"
+   - If uat selected: "UAT domain (e.g., uat.myapp.example.com)"
+   - If dev selected: "Dev domain (e.g., dev.myapp.example.com)"
+
+### Additional questions for monorepo
+
+If the repo is a monorepo, also ask:
+
+7. Product name — the identifier used in workflow filenames and CapRover app names. Example: "faabzi"
+8. Client path — the path to the product directory relative to repo root. Example: "clients/faabzi"
+
+Store all collected values before proceeding to Phase 3.
+
+## Phase 3: Generate Workflow
+
+1. Select the template based on repo type:
+   - Standalone: `${CLAUDE_PLUGIN_ROOT}/templates/deploy-standalone.yml`
+   - Monorepo: `${CLAUDE_PLUGIN_ROOT}/templates/deploy-monorepo-product.yml`
+
+2. Read the template file.
+
+3. Replace all `__PLACEHOLDER__` tokens with the collected values. The following tokens are used in the templates:
+
+   | Token | Value |
+   |-------|-------|
+   | `__APP_NAME__` | App name collected in Phase 2 |
+   | `__CONTAINER_PORT__` | Container port |
+   | `__HEALTH_PATH__` | Health check path |
+   | `__GITHUB_OWNER__` | GitHub owner for GHCR |
+   | `__PROD_DOMAIN__` | Production domain (if prod selected) |
+   | `__UAT_DOMAIN__` | UAT domain (if uat selected) |
+   | `__DEV_DOMAIN__` | Dev domain (monorepo only; standalone derives dev URL from SHA) |
+   | `__PRODUCT_NAME__` | Product name (monorepo only) |
+   | `__CLIENT_PATH__` | Client path (monorepo only) |
+
+   For environments not selected, remove the corresponding job blocks from the generated workflow rather than leaving placeholder tokens.
+
+4. Determine the output path:
+   - Standalone: `.github/workflows/deploy.yml`
+   - Monorepo: `.github/workflows/deploy-<product>.yml`
+   - If the user chose "create alongside" in Phase 1, append `-new` before `.yml`.
+
+5. Create the `.github/workflows/` directory if it does not exist.
+
+6. Write the generated workflow to the output path.
+
+## Phase 4: Copy Scripts
+
+1. List all files in `${CLAUDE_PLUGIN_ROOT}/scripts/`.
+2. Create `.github/scripts/` in the target repo if it does not exist.
+3. For each script file, read it and write it to `.github/scripts/<filename>`.
+4. Make each script executable: run `chmod +x .github/scripts/<filename>` for each file.
+
+Do not overwrite scripts that already exist in `.github/scripts/` unless they are identical in name to plugin scripts. If a conflict exists, warn the user and skip that file.
+
+## Phase 5: Generate .env.deploy.example
+
+Create `.env.deploy.example` in the repo root with the following content:
+
+```
+# Required GitHub Secrets for deployment
+# Add these in Settings > Secrets and variables > Actions
+
+# CapRover (OCI_MAIN - prod/uat)
+CAPROVER_URL=https://captain.app.qwickforge.com
+CAPROVER_PASSWORD=
+
+# CapRover (OCI_DEV - dev)
+OCI_DEV_CAPROVER_URL=https://captain.dev.qwickforge.com
+OCI_DEV_CAPROVER_PASSWORD=
+
+# QwickWay Gateway (route)
+ROUTE_CAPROVER_URL=https://captain.route.qwickforge.com
+ROUTE_CAPROVER_PASSWORD=
+
+# GHCR pull token (for CapRover to pull images)
+GHCR_PULL_TOKEN=
+```
+
+If only a subset of environments was selected in Phase 2, include only the secrets relevant to those environments:
+- prod and uat require `CAPROVER_URL` and `CAPROVER_PASSWORD`
+- dev requires `OCI_DEV_CAPROVER_URL` and `OCI_DEV_CAPROVER_PASSWORD`
+- Any environment with a QwickWay gateway requires `ROUTE_CAPROVER_URL` and `ROUTE_CAPROVER_PASSWORD`
+- All environments require `GHCR_PULL_TOKEN`
+
+## Phase 6: Summary
+
+Print a structured summary of what was generated. Use plain text, no emojis.
+
+```
+Setup complete.
+
+Files created:
+  .github/workflows/<workflow-file>.yml
+  .github/scripts/configure-caprover-app.sh
+  .github/scripts/deploy-from-ghcr.sh
+  .github/scripts/validate-deployment-health.sh
+  .github/scripts/setup-ghcr-package.sh
+  .github/scripts/setup-qwickway-route.sh
+  .github/scripts/cleanup-dev-builds.sh
+  .env.deploy.example
+
+GitHub Secrets to configure:
+  See .env.deploy.example for the full list.
+  Add secrets at: https://github.com/<owner>/<repo>/settings/secrets/actions
+
+How to test:
+  Push to dev branch to trigger a dev deployment.
+
+How to deploy to UAT:
+  Push to main branch.
+
+How to deploy to production:
+  Standalone: Create a tag matching v* (e.g., git tag v1.0.0 && git push --tags).
+  Monorepo: Create a tag matching <app>-v* (e.g., git tag faabzi-v1.0.0 && git push --tags).
+```
+
+Replace `<owner>/<repo>` with the actual GitHub remote if it can be determined from `git remote -v`. Otherwise leave the placeholder.

--- a/plugins/deploy/scripts/cleanup-dev-builds.sh
+++ b/plugins/deploy/scripts/cleanup-dev-builds.sh
@@ -1,0 +1,419 @@
+#!/bin/bash
+set -e
+
+# Cleanup Dev Builds
+# Manages per-commit dev builds on CapRover. Keeps the last N builds and
+# deletes older ones, then optionally updates the dev gateway to point to
+# the latest surviving build.
+#
+# Usage:
+#   ./cleanup-dev-builds.sh \
+#     --app-name-prefix <prefix> \
+#     --caprover-url <url> \
+#     --caprover-password <password> \
+#     [--keep-count <n>] \
+#     [--route-caprover-url <url>] \
+#     [--route-caprover-password <password>] \
+#     [--gateway-app-name <name>] \
+#     [--dev-domain-suffix <suffix>]
+
+# Retry wrapper for CapRover API calls
+# Usage: caprover_api_call <description> <curl_command...>
+caprover_api_call() {
+  local description="$1"
+  shift
+  local max_retries=5
+  local retry_delay=10
+  local attempt=1
+
+  while [ $attempt -le $max_retries ]; do
+    echo "  Attempt $attempt/$max_retries: $description" >&2
+
+    # Execute curl command and capture response
+    local response
+    response=$("$@")
+
+    # Check if CapRover is busy
+    if echo "$response" | grep -iq "another operation.*in progress\|operation.*still in progress\|please wait"; then
+      if [ $attempt -lt $max_retries ]; then
+        echo "  CapRover is busy with another operation" >&2
+        echo "  Waiting ${retry_delay}s before retry..." >&2
+        sleep $retry_delay
+
+        # Exponential backoff: double the delay for next retry (max 60s)
+        retry_delay=$((retry_delay * 2))
+        if [ $retry_delay -gt 60 ]; then
+          retry_delay=60
+        fi
+
+        attempt=$((attempt + 1))
+        continue
+      else
+        echo "  CapRover still busy after $max_retries attempts" >&2
+        echo "  Response: $response" >&2
+        return 1
+      fi
+    fi
+
+    # Success - return response (to stdout only)
+    echo "$response"
+    return 0
+  done
+
+  # Should never reach here, but just in case
+  return 1
+}
+
+# Parse arguments
+APP_NAME_PREFIX=""
+KEEP_COUNT=3
+CAPROVER_URL=""
+CAPROVER_PASSWORD=""
+ROUTE_CAPROVER_URL=""
+ROUTE_CAPROVER_PASSWORD=""
+GATEWAY_APP_NAME=""
+DEV_DOMAIN_SUFFIX="dev.qwickforge.com"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --app-name-prefix)
+      APP_NAME_PREFIX="$2"
+      shift 2
+      ;;
+    --keep-count)
+      KEEP_COUNT="$2"
+      shift 2
+      ;;
+    --caprover-url)
+      CAPROVER_URL="$2"
+      shift 2
+      ;;
+    --caprover-password)
+      CAPROVER_PASSWORD="$2"
+      shift 2
+      ;;
+    --route-caprover-url)
+      ROUTE_CAPROVER_URL="$2"
+      shift 2
+      ;;
+    --route-caprover-password)
+      ROUTE_CAPROVER_PASSWORD="$2"
+      shift 2
+      ;;
+    --gateway-app-name)
+      GATEWAY_APP_NAME="$2"
+      shift 2
+      ;;
+    --dev-domain-suffix)
+      DEV_DOMAIN_SUFFIX="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "$APP_NAME_PREFIX" ] || [ -z "$CAPROVER_URL" ] || [ -z "$CAPROVER_PASSWORD" ]; then
+  echo "Error: Missing required arguments"
+  echo "Usage: $0 --app-name-prefix <prefix> --caprover-url <url> --caprover-password <password>"
+  exit 1
+fi
+
+# Validate route params: all three must be provided together or not at all
+ROUTE_PARAMS_COUNT=0
+[ -n "$ROUTE_CAPROVER_URL" ] && ROUTE_PARAMS_COUNT=$((ROUTE_PARAMS_COUNT + 1))
+[ -n "$ROUTE_CAPROVER_PASSWORD" ] && ROUTE_PARAMS_COUNT=$((ROUTE_PARAMS_COUNT + 1))
+[ -n "$GATEWAY_APP_NAME" ] && ROUTE_PARAMS_COUNT=$((ROUTE_PARAMS_COUNT + 1))
+
+if [ "$ROUTE_PARAMS_COUNT" -gt 0 ] && [ "$ROUTE_PARAMS_COUNT" -lt 3 ]; then
+  echo "Error: --route-caprover-url, --route-caprover-password, and --gateway-app-name must all be provided together"
+  exit 1
+fi
+
+UPDATE_GATEWAY=false
+if [ "$ROUTE_PARAMS_COUNT" -eq 3 ]; then
+  UPDATE_GATEWAY=true
+fi
+
+if ! [[ "$KEEP_COUNT" =~ ^[0-9]+$ ]] || [ "$KEEP_COUNT" -lt 1 ]; then
+  echo "Error: --keep-count must be a positive integer, got '$KEEP_COUNT'"
+  exit 1
+fi
+
+echo "========================================="
+echo "Cleanup Dev Builds"
+echo "========================================="
+echo "Prefix: $APP_NAME_PREFIX"
+echo "Keep count: $KEEP_COUNT"
+echo "CapRover: $CAPROVER_URL"
+echo "Gateway update: $UPDATE_GATEWAY"
+if [ "$UPDATE_GATEWAY" = true ]; then
+  echo "Route CapRover: $ROUTE_CAPROVER_URL"
+  echo "Gateway app: $GATEWAY_APP_NAME"
+  echo "Dev domain suffix: $DEV_DOMAIN_SUFFIX"
+fi
+echo "========================================="
+
+# Authenticate with dev CapRover
+echo ""
+echo "Authenticating with dev CapRover..."
+LOGIN_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg pw "$CAPROVER_PASSWORD" '{password: $pw}')")
+
+if ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: Dev CapRover returned non-JSON response (server may be down)"
+  exit 1
+fi
+
+LOGIN_STATUS=$(echo "$LOGIN_RESPONSE" | jq -r '.status')
+if [ "$LOGIN_STATUS" != "100" ]; then
+  echo "Error: Authentication failed with dev CapRover (status: $LOGIN_STATUS)"
+  exit 1
+fi
+
+DEV_TOKEN=$(echo "$LOGIN_RESPONSE" | jq -r '.data.token')
+if [ -z "$DEV_TOKEN" ] || [ "$DEV_TOKEN" = "null" ]; then
+  echo "Error: Failed to extract auth token from dev CapRover"
+  exit 1
+fi
+
+echo "  Authenticated"
+
+# Fetch all app definitions
+echo ""
+echo "Fetching app definitions..."
+APPS_RESPONSE=$(curl -s -k -X GET "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $DEV_TOKEN")
+
+APPS_STATUS=$(echo "$APPS_RESPONSE" | jq -r '.status')
+if [ "$APPS_STATUS" != "100" ]; then
+  echo "Error: Failed to fetch app definitions (status: $APPS_STATUS)"
+  echo "Response: $APPS_RESPONSE"
+  exit 1
+fi
+
+echo "  Fetched app definitions"
+
+# Protected names that must never be deleted
+PROTECTED_EXACT=(
+  "$APP_NAME_PREFIX"
+  "${APP_NAME_PREFIX}-dev"
+  "${APP_NAME_PREFIX}-uat"
+)
+
+# Filter apps matching <APP_NAME_PREFIX>-* and exclude protected names.
+# Then sort by the most recent deploy timestamp descending (epoch ms from versions array).
+# Apps with no versions get timestamp 0 and sort last.
+CANDIDATE_APPS=$(echo "$APPS_RESPONSE" | jq -r \
+  --arg prefix "${APP_NAME_PREFIX}-" \
+  --argjson protected "$(printf '%s\n' "${PROTECTED_EXACT[@]}" | jq -R . | jq -s .)" \
+  '[
+    .data.appDefinitions[]
+    | select(.appName | startswith($prefix))
+    | select(.appName as $n | $protected | index($n) == null)
+    | {
+        name: .appName,
+        ts: (
+          if (.versions | length) > 0 then
+            (.versions | map(.timeStamp) | max)
+          else
+            0
+          end
+        )
+      }
+  ]
+  | sort_by(-.ts)
+  | .[]
+  | "\(.ts)\t\(.name)"')
+
+if [ -z "$CANDIDATE_APPS" ]; then
+  echo ""
+  echo "========================================="
+  echo "No candidate dev builds found"
+  echo "========================================="
+  echo "Prefix: ${APP_NAME_PREFIX}-*"
+  echo "Nothing to delete."
+  echo "========================================="
+  exit 0
+fi
+
+TOTAL_COUNT=$(echo "$CANDIDATE_APPS" | wc -l | tr -d ' ')
+echo ""
+echo "Found $TOTAL_COUNT candidate build(s) matching '${APP_NAME_PREFIX}-*':"
+echo "$CANDIDATE_APPS" | while IFS=$'\t' read -r ts name; do
+  echo "  $name (ts: $ts)"
+done
+
+# Split into keep and delete sets
+BUILDS_TO_KEEP=()
+BUILDS_TO_DELETE=()
+INDEX=0
+
+while IFS=$'\t' read -r ts name; do
+  INDEX=$((INDEX + 1))
+  if [ "$INDEX" -le "$KEEP_COUNT" ]; then
+    BUILDS_TO_KEEP+=("$name")
+  else
+    BUILDS_TO_DELETE+=("$name")
+  fi
+done <<< "$CANDIDATE_APPS"
+
+echo ""
+echo "Keeping $KEEP_COUNT most recent build(s):"
+for name in "${BUILDS_TO_KEEP[@]}"; do
+  echo "  $name"
+done
+
+if [ "${#BUILDS_TO_DELETE[@]}" -eq 0 ]; then
+  echo ""
+  echo "No builds to delete (total: $TOTAL_COUNT, keep: $KEEP_COUNT)."
+else
+  echo ""
+  echo "Deleting ${#BUILDS_TO_DELETE[@]} older build(s):"
+  DELETE_FAILURES=0
+  for name in "${BUILDS_TO_DELETE[@]}"; do
+    echo "  Deleting $name..."
+    DELETE_RESPONSE=$(caprover_api_call "Delete app $name" \
+      curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/delete" \
+      -H "Content-Type: application/json" \
+      -H "x-captain-auth: $DEV_TOKEN" \
+      -d "$(jq -n --arg name "$name" '{appName: $name}')")
+
+    DELETE_STATUS=$(echo "$DELETE_RESPONSE" | jq -r '.status')
+    if [ "$DELETE_STATUS" != "100" ]; then
+      DELETE_DESC=$(echo "$DELETE_RESPONSE" | jq -r '.description // "Unknown error"')
+      echo "  Warning: Failed to delete $name: $DELETE_DESC (status: $DELETE_STATUS)"
+      DELETE_FAILURES=$((DELETE_FAILURES + 1))
+      continue
+    fi
+
+    echo "    Deleted $name"
+  done
+
+  if [ "$DELETE_FAILURES" -gt 0 ]; then
+    echo "  Warning: $DELETE_FAILURES deletion(s) failed"
+  fi
+fi
+
+# Determine the latest surviving build (first in sorted list)
+LATEST_BUILD=$(echo "$CANDIDATE_APPS" | head -1 | cut -f2)
+
+echo ""
+echo "========================================="
+echo "Cleanup complete"
+echo "========================================="
+echo "Kept:    ${#BUILDS_TO_KEEP[@]} build(s)"
+echo "Deleted: ${#BUILDS_TO_DELETE[@]} build(s)"
+echo "Latest:  $LATEST_BUILD"
+echo "========================================="
+
+# Gateway update (optional)
+if [ "$UPDATE_GATEWAY" = false ]; then
+  exit 0
+fi
+
+LATEST_URL="https://${LATEST_BUILD}.${DEV_DOMAIN_SUFFIX}"
+
+echo ""
+echo "========================================="
+echo "Updating dev gateway"
+echo "========================================="
+echo "Gateway app: $GATEWAY_APP_NAME"
+echo "Target URL:  $LATEST_URL"
+echo "========================================="
+
+# Authenticate with route CapRover
+echo ""
+echo "Authenticating with route CapRover..."
+ROUTE_LOGIN_RESPONSE=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg pw "$ROUTE_CAPROVER_PASSWORD" '{password: $pw}')")
+
+if ! echo "$ROUTE_LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: Route CapRover returned non-JSON response (server may be down)"
+  exit 1
+fi
+
+ROUTE_LOGIN_STATUS=$(echo "$ROUTE_LOGIN_RESPONSE" | jq -r '.status')
+if [ "$ROUTE_LOGIN_STATUS" != "100" ]; then
+  echo "Error: Authentication failed with route CapRover (status: $ROUTE_LOGIN_STATUS)"
+  exit 1
+fi
+
+ROUTE_TOKEN=$(echo "$ROUTE_LOGIN_RESPONSE" | jq -r '.data.token')
+if [ -z "$ROUTE_TOKEN" ] || [ "$ROUTE_TOKEN" = "null" ]; then
+  echo "Error: Failed to extract auth token from route CapRover"
+  exit 1
+fi
+
+echo "  Authenticated"
+
+# Fetch the gateway app definition
+echo ""
+echo "Fetching gateway app definition..."
+GATEWAY_RESPONSE=$(curl -s -k -X GET "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $ROUTE_TOKEN")
+
+GATEWAY_APPS_STATUS=$(echo "$GATEWAY_RESPONSE" | jq -r '.status')
+if [ "$GATEWAY_APPS_STATUS" != "100" ]; then
+  echo "Error: Failed to fetch gateway app definitions (status: $GATEWAY_APPS_STATUS)"
+  echo "Response: $GATEWAY_RESPONSE"
+  exit 1
+fi
+
+GATEWAY_APP=$(echo "$GATEWAY_RESPONSE" | jq \
+  --arg name "$GATEWAY_APP_NAME" \
+  '.data.appDefinitions[] | select(.appName == $name)')
+
+if [ -z "$GATEWAY_APP" ] || [ "$GATEWAY_APP" = "null" ]; then
+  echo "Error: Gateway app '$GATEWAY_APP_NAME' not found on route CapRover"
+  exit 1
+fi
+
+echo "  Found gateway app"
+
+# Build updated env vars array: replace TARGET_APP if present, otherwise append it
+UPDATED_ENV_VARS=$(echo "$GATEWAY_APP" | jq \
+  --arg url "$LATEST_URL" \
+  '
+  .envVars as $existing |
+  if ($existing | map(select(.key == "TARGET_APP")) | length) > 0 then
+    $existing | map(if .key == "TARGET_APP" then .value = $url else . end)
+  else
+    $existing + [{"key": "TARGET_APP", "value": $url}]
+  end
+  ')
+
+# Construct the update payload: full read-then-write merge to preserve all fields
+UPDATE_PAYLOAD=$(echo "$GATEWAY_APP" | jq \
+  --argjson envVars "$UPDATED_ENV_VARS" \
+  '.envVars = $envVars')
+
+echo ""
+echo "Updating gateway TARGET_APP env var..."
+UPDATE_RESPONSE=$(caprover_api_call "Update gateway app definition" \
+  curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions/update" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $ROUTE_TOKEN" \
+  -d "$UPDATE_PAYLOAD")
+
+UPDATE_STATUS=$(echo "$UPDATE_RESPONSE" | jq -r '.status')
+if [ "$UPDATE_STATUS" != "100" ]; then
+  UPDATE_DESC=$(echo "$UPDATE_RESPONSE" | jq -r '.description // "Unknown error"')
+  echo "Error: Failed to update gateway app: $UPDATE_DESC (status: $UPDATE_STATUS)"
+  exit 1
+fi
+
+echo "  Updated TARGET_APP to: $LATEST_URL"
+
+echo ""
+echo "========================================="
+echo "Gateway update complete"
+echo "========================================="
+echo "App:        $GATEWAY_APP_NAME"
+echo "TARGET_APP: $LATEST_URL"
+echo "========================================="

--- a/plugins/deploy/scripts/configure-caprover-app.sh
+++ b/plugins/deploy/scripts/configure-caprover-app.sh
@@ -1,0 +1,360 @@
+#!/bin/bash
+set -e
+
+# Configure CapRover App Script
+# Configures app settings: instance count, ports, SSL, HTTPS, env vars
+#
+# Uses read-then-write: fetches the full current app definition from CapRover
+# before updating, so that only the specified fields are changed and all other
+# existing settings (volumes, persistent dirs, custom config, etc.) are preserved.
+#
+# Enhancement: env var diff comparison. After building the merged definition,
+# compares current envVars with desired envVars (sorted by key via jq). If
+# identical and --skip-env-if-unchanged is true (default), envVars are removed
+# from the update payload so they do not trigger an unnecessary container restart.
+#
+# Usage:
+#   ./configure-caprover-app.sh \
+#     --app-name <name> \
+#     --caprover-url <url> \
+#     --caprover-password <password> \
+#     --instance-count <count> \
+#     --container-port <port> \
+#     --force-ssl <true|false> \
+#     --env-file <path> \
+#     --skip-env-if-unchanged <true|false>
+
+# Retry wrapper for CapRover API calls
+# Usage: caprover_api_call <description> <curl_command...>
+caprover_api_call() {
+  local description="$1"
+  shift
+  local max_retries=5
+  local retry_delay=10
+  local attempt=1
+
+  while [ $attempt -le $max_retries ]; do
+    echo "  Attempt $attempt/$max_retries: $description" >&2
+
+    # Execute curl command and capture response
+    local response
+    response=$("$@")
+
+    # Check if CapRover is busy
+    if echo "$response" | grep -iq "another operation.*in progress\|operation.*still in progress\|please wait"; then
+      if [ $attempt -lt $max_retries ]; then
+        echo "  CapRover is busy with another operation" >&2
+        echo "  Waiting ${retry_delay}s before retry..." >&2
+        sleep $retry_delay
+
+        # Exponential backoff: double the delay for next retry (max 60s)
+        retry_delay=$((retry_delay * 2))
+        if [ $retry_delay -gt 60 ]; then
+          retry_delay=60
+        fi
+
+        attempt=$((attempt + 1))
+        continue
+      else
+        echo "  CapRover still busy after $max_retries attempts" >&2
+        echo "  Response: $response" >&2
+        return 1
+      fi
+    fi
+
+    # Success - return response (to stdout only)
+    echo "$response"
+    return 0
+  done
+
+  # Should never reach here, but just in case
+  return 1
+}
+
+# Parse arguments
+APP_NAME=""
+CAPROVER_URL=""
+CAPROVER_PASSWORD=""
+INSTANCE_COUNT=1
+CONTAINER_PORT=3000
+FORCE_SSL="true"
+ENABLE_SSL="true"
+ENV_FILE=""
+DOMAINS=""
+SKIP_ENV_IF_UNCHANGED="true"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --caprover-url)
+      CAPROVER_URL="$2"
+      shift 2
+      ;;
+    --caprover-password)
+      CAPROVER_PASSWORD="$2"
+      shift 2
+      ;;
+    --instance-count)
+      INSTANCE_COUNT="$2"
+      shift 2
+      ;;
+    --container-port)
+      CONTAINER_PORT="$2"
+      shift 2
+      ;;
+    --force-ssl)
+      FORCE_SSL="$2"
+      shift 2
+      ;;
+    --enable-ssl)
+      ENABLE_SSL="$2"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --domains)
+      DOMAINS="$2"
+      shift 2
+      ;;
+    --skip-env-if-unchanged)
+      SKIP_ENV_IF_UNCHANGED="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "$APP_NAME" ] || [ -z "$CAPROVER_URL" ] || [ -z "$CAPROVER_PASSWORD" ]; then
+  echo "Error: Missing required arguments"
+  exit 1
+fi
+
+# Validate boolean arguments
+case "$FORCE_SSL" in
+  true|false) ;;
+  *) echo "Error: --force-ssl must be 'true' or 'false', got '$FORCE_SSL'"; exit 1 ;;
+esac
+
+echo "========================================="
+echo "Configure CapRover App"
+echo "========================================="
+echo "App: $APP_NAME"
+echo "Instance Count: $INSTANCE_COUNT"
+echo "Container Port: $CONTAINER_PORT"
+echo "Force SSL: $FORCE_SSL"
+echo "Skip Env If Unchanged: $SKIP_ENV_IF_UNCHANGED"
+echo "========================================="
+
+# Authenticate with CapRover
+echo ""
+echo "Authenticating with CapRover..."
+LOGIN_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg pw "$CAPROVER_PASSWORD" '{password: $pw}')")
+
+if ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: CapRover returned non-JSON response (server may be down)"
+  exit 1
+fi
+
+LOGIN_STATUS=$(echo "$LOGIN_RESPONSE" | jq -r '.status')
+if [ "$LOGIN_STATUS" != "100" ]; then
+  echo "Error: Authentication failed (status: $LOGIN_STATUS)"
+  exit 1
+fi
+
+TOKEN=$(echo "$LOGIN_RESPONSE" | jq -r '.data.token')
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Error: Failed to extract auth token"
+  exit 1
+fi
+echo "  Authenticated"
+
+# Ensure app exists
+echo ""
+echo "Ensuring app exists..."
+CREATE_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/register" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$(jq -n --arg name "$APP_NAME" '{appName: $name, hasPersistentData: false}')")
+
+# Check if response is valid JSON
+if ! echo "$CREATE_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "  Error: Invalid JSON response from CapRover:"
+  echo "$CREATE_RESPONSE"
+  exit 1
+fi
+
+CREATE_STATUS=$(echo "$CREATE_RESPONSE" | jq -r '.status')
+APP_ALREADY_EXISTS=false
+
+if [ "$CREATE_STATUS" = "100" ]; then
+  echo "  App created"
+  APP_ALREADY_EXISTS=false
+elif [ "$CREATE_STATUS" = "1901" ]; then
+  echo "  App already exists"
+  APP_ALREADY_EXISTS=true
+else
+  DESC=$(echo "$CREATE_RESPONSE" | jq -r '.description')
+  if echo "$DESC" | grep -q "already exists"; then
+    echo "  App already exists"
+    APP_ALREADY_EXISTS=true
+  else
+    echo "  Warning: Unexpected response: $DESC"
+    APP_ALREADY_EXISTS=false
+  fi
+fi
+
+# Fetch current app definition (read-then-write: preserves all existing fields)
+echo ""
+echo "Fetching current app definition..."
+ALL_DEFS=$(curl -s -k -X GET "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $TOKEN")
+
+CURRENT_DEF=$(echo "$ALL_DEFS" | jq --arg name "$APP_NAME" '.data.appDefinitions[] | select(.appName == $name)')
+
+if [ -z "$CURRENT_DEF" ] || [ "$CURRENT_DEF" = "null" ]; then
+  echo "  Error: Could not fetch app definition for $APP_NAME"
+  exit 1
+fi
+
+echo "  Fetched app definition"
+
+# Merge settings into current definition
+# Only the specified fields are changed; all other existing settings are preserved
+echo ""
+echo "Configuring app settings..."
+MERGED=$(echo "$CURRENT_DEF" | jq \
+  --argjson count "$INSTANCE_COUNT" \
+  --argjson port "$CONTAINER_PORT" \
+  --argjson ssl "$FORCE_SSL" \
+  '.instanceCount = $count | .containerHttpPort = $port | .forceSsl = $ssl | .websocketSupport = true | .appDeployTokenConfig = (.appDeployTokenConfig // {} | .enabled = true)')
+
+# Merge environment variables if env file provided
+if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+  echo ""
+  echo "Configuring environment variables from $ENV_FILE..."
+
+  # Read env file and convert to JSON array
+  ENV_VARS="[]"
+  while IFS= read -r line; do
+    # Skip comments and empty lines
+    [[ "$line" =~ ^[[:space:]]*#.*$ ]] && continue
+    [[ -z "$(echo "$line" | tr -d '[:space:]')" ]] && continue
+
+    # Strip optional 'export ' prefix and leading whitespace
+    line=$(echo "$line" | sed 's/^[[:space:]]*//' | sed 's/^export //')
+
+    # Split on first = only
+    key="${line%%=*}"
+    value="${line#*=}"
+
+    # Skip if no = found
+    [ "$key" = "$line" ] && continue
+
+    # Trim whitespace from key
+    key=$(echo "$key" | tr -d '[:space:]')
+
+    # Remove surrounding quotes from value if present
+    value=$(echo "$value" | sed 's/^["'\'']//' | sed 's/["'\'']$//')
+
+    # Add to JSON array
+    ENV_VARS=$(echo "$ENV_VARS" | jq --arg k "$key" --arg v "$value" '. += [{key: $k, value: $v}]')
+  done < "$ENV_FILE"
+
+  if [ "$ENV_VARS" != "[]" ]; then
+    VAR_COUNT=$(echo "$ENV_VARS" | jq 'length')
+
+    # Env var diff comparison: compare desired vars against current vars.
+    # Sort both arrays by key before comparing so order differences are ignored.
+    # If identical and --skip-env-if-unchanged is true, omit envVars from the
+    # update payload to avoid an unnecessary container restart.
+    CURRENT_ENV_SORTED=$(echo "$CURRENT_DEF" | jq -cS '.envVars // [] | sort_by(.key)')
+    DESIRED_ENV_SORTED=$(echo "$ENV_VARS" | jq -cS 'sort_by(.key)')
+
+    if [ "$SKIP_ENV_IF_UNCHANGED" = "true" ] && [ "$CURRENT_ENV_SORTED" = "$DESIRED_ENV_SORTED" ]; then
+      echo "  Env vars unchanged ($VAR_COUNT vars). Skipping env update to avoid unnecessary restart."
+      # Do not set envVars in MERGED; leave the current value intact via the
+      # read-then-write approach (CURRENT_DEF already contains the correct envVars).
+    else
+      MERGED=$(echo "$MERGED" | jq --argjson vars "$ENV_VARS" '.envVars = $vars')
+      echo "  Merged $VAR_COUNT environment variables (changes detected, update will apply)"
+    fi
+  fi
+fi
+
+# Write: POST full merged definition back (single call preserves all other fields)
+UPDATE_RESPONSE=$(caprover_api_call "Update app" \
+  curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/update" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$MERGED")
+
+UPDATE_STATUS=$(echo "$UPDATE_RESPONSE" | jq -r '.status')
+
+if [ "$UPDATE_STATUS" = "100" ] || [ "$UPDATE_STATUS" = "1000" ]; then
+  echo "  App settings updated"
+else
+  echo "  Warning: Update response: $(echo "$UPDATE_RESPONSE" | jq -r '.description')"
+fi
+
+# Configure domains and SSL (only for new apps - existing apps keep their domain config)
+if [ "$APP_ALREADY_EXISTS" = "false" ]; then
+  if [ -n "$DOMAINS" ]; then
+    echo ""
+    echo "Configuring domains..."
+
+    IFS=',' read -ra DOMAIN_ARRAY <<< "$DOMAINS"
+    for domain in "${DOMAIN_ARRAY[@]}"; do
+      domain=$(echo "$domain" | xargs)  # trim whitespace
+
+      echo "  Adding domain: $domain"
+      DOMAIN_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/customdomain" \
+        -H "Content-Type: application/json" \
+        -H "x-captain-auth: $TOKEN" \
+        -d "$(jq -n --arg app "$APP_NAME" --arg dom "$domain" '{appName: $app, customDomain: $dom}')")
+
+      DOMAIN_STATUS=$(echo "$DOMAIN_RESPONSE" | jq -r '.status')
+      if [ "$DOMAIN_STATUS" = "100" ]; then
+        echo "    Domain added"
+      else
+        echo "    $(echo "$DOMAIN_RESPONSE" | jq -r '.description')"
+      fi
+    done
+
+    # Enable SSL per custom domain if requested
+    if [ "$ENABLE_SSL" = "true" ]; then
+      echo ""
+      echo "Enabling SSL..."
+
+      for domain in "${DOMAIN_ARRAY[@]}"; do
+        domain=$(echo "$domain" | xargs)
+        SSL_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/enablecustomdomainssl" \
+          -H "Content-Type: application/json" \
+          -H "x-captain-auth: $TOKEN" \
+          -d "$(jq -n --arg app "$APP_NAME" --arg dom "$domain" '{appName: $app, customDomain: $dom}')")
+
+        SSL_STATUS=$(echo "$SSL_RESPONSE" | jq -r '.status')
+        if [ "$SSL_STATUS" = "100" ]; then
+          echo "  SSL enabled for $domain"
+        else
+          echo "  $(echo "$SSL_RESPONSE" | jq -r '.description')"
+        fi
+      done
+    fi
+  fi
+fi
+
+echo ""
+echo "========================================="
+echo "Configuration complete"
+echo "========================================="

--- a/plugins/deploy/scripts/deploy-from-ghcr.sh
+++ b/plugins/deploy/scripts/deploy-from-ghcr.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+set -e
+
+# Deploy from GHCR to CapRover
+# Configures registry credentials and deploys Docker image from GitHub Container Registry
+#
+# Usage:
+#   ./deploy-from-ghcr.sh \
+#     --app-name <name> \
+#     --image-ref <ref> \
+#     --caprover-url <url> \
+#     --caprover-password <password> \
+#     --github-token <token> \
+#     --github-owner <owner>
+
+# Retry wrapper for CapRover API calls
+# Usage: caprover_api_call <description> <curl_command...>
+caprover_api_call() {
+  local description="$1"
+  shift
+  local max_retries=5
+  local retry_delay=10
+  local attempt=1
+
+  while [ $attempt -le $max_retries ]; do
+    echo "  Attempt $attempt/$max_retries: $description" >&2
+
+    # Execute curl command and capture response
+    local response
+    response=$("$@")
+
+    # Check if CapRover is busy
+    if echo "$response" | grep -iq "another operation.*in progress\|operation.*still in progress\|please wait"; then
+      if [ $attempt -lt $max_retries ]; then
+        echo "  CapRover is busy with another operation" >&2
+        echo "  Waiting ${retry_delay}s before retry..." >&2
+        sleep $retry_delay
+
+        # Exponential backoff: double the delay for next retry (max 60s)
+        retry_delay=$((retry_delay * 2))
+        if [ $retry_delay -gt 60 ]; then
+          retry_delay=60
+        fi
+
+        attempt=$((attempt + 1))
+        continue
+      else
+        echo "  CapRover still busy after $max_retries attempts" >&2
+        echo "  Response: $response" >&2
+        return 1
+      fi
+    fi
+
+    # Success - return response (to stdout only)
+    echo "$response"
+    return 0
+  done
+
+  # Should never reach here, but just in case
+  return 1
+}
+
+# Parse arguments
+APP_NAME=""
+IMAGE_REF=""
+CAPROVER_URL=""
+CAPROVER_PASSWORD=""
+GITHUB_TOKEN=""
+GITHUB_OWNER="qwickapps"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --image-ref)
+      IMAGE_REF="$2"
+      shift 2
+      ;;
+    --caprover-url)
+      CAPROVER_URL="$2"
+      shift 2
+      ;;
+    --caprover-password)
+      CAPROVER_PASSWORD="$2"
+      shift 2
+      ;;
+    --github-token)
+      GITHUB_TOKEN="$2"
+      shift 2
+      ;;
+    --github-owner)
+      GITHUB_OWNER="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "$APP_NAME" ] || [ -z "$IMAGE_REF" ] || [ -z "$CAPROVER_URL" ] || [ -z "$CAPROVER_PASSWORD" ] || [ -z "$GITHUB_TOKEN" ]; then
+  echo "Error: Missing required arguments"
+  echo "Usage: $0 --app-name <name> --image-ref <ref> --caprover-url <url> --caprover-password <password> --github-token <token>"
+  exit 1
+fi
+
+echo "========================================="
+echo "Deploy from GHCR"
+echo "========================================="
+echo "App: $APP_NAME"
+echo "Image: $IMAGE_REF"
+echo "CapRover: $CAPROVER_URL"
+echo "========================================="
+
+# Authenticate with CapRover
+echo ""
+echo "Authenticating with CapRover..."
+TOKEN=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"password\":\"$CAPROVER_PASSWORD\"}" | jq -r '.data.token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Error: Failed to authenticate"
+  exit 1
+fi
+
+echo "  Authenticated"
+
+# Always refresh GHCR registry credentials in CapRover.
+# Stale entries from prior runs cause Internal Server Errors on deploy.
+echo ""
+echo "Refreshing GHCR registry credentials..."
+
+REGISTRIES_RESPONSE=$(curl -s -k -X GET "$CAPROVER_URL/api/v2/user/registries" \
+  -H "x-captain-auth: $TOKEN")
+
+# Delete all existing ghcr.io registry entries (may be multiple stale ones)
+EXISTING_IDS=$(echo "$REGISTRIES_RESPONSE" | jq -r '.data.registries[] | select(.registryDomain == "ghcr.io") | .id' 2>/dev/null || true)
+
+if [ -n "$EXISTING_IDS" ]; then
+  ENTRY_COUNT=$(echo "$EXISTING_IDS" | wc -l | tr -d ' ')
+  echo "  Found $ENTRY_COUNT existing ghcr.io entry/entries - removing stale credentials"
+  while IFS= read -r registry_id; do
+    [ -z "$registry_id" ] && continue
+    curl -s -k -X POST "$CAPROVER_URL/api/v2/user/registries/delete" \
+      -H "Content-Type: application/json" \
+      -H "x-captain-auth: $TOKEN" \
+      -d "{\"id\":\"$registry_id\"}" >/dev/null 2>&1 || true
+  done <<< "$EXISTING_IDS"
+fi
+
+# Insert fresh credentials
+REGISTRY_RESPONSE=$(caprover_api_call "Insert GHCR registry" \
+  curl -s -k -X POST "$CAPROVER_URL/api/v2/user/registries/insert" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "{\"registryUser\":\"x-access-token\",\"registryPassword\":\"$GITHUB_TOKEN\",\"registryDomain\":\"ghcr.io\",\"registryImagePrefix\":\"\"}")
+
+if ! echo "$REGISTRY_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "  Error: CapRover returned invalid JSON when adding credentials"
+  echo "  Response: $REGISTRY_RESPONSE"
+  exit 1
+fi
+
+REGISTRY_STATUS=$(echo "$REGISTRY_RESPONSE" | jq -r '.status')
+if [ "$REGISTRY_STATUS" != "100" ]; then
+  REGISTRY_DESC=$(echo "$REGISTRY_RESPONSE" | jq -r '.description // "Unknown error"')
+  echo "  Error: Failed to add registry credentials: $REGISTRY_DESC (status: $REGISTRY_STATUS)"
+  exit 1
+fi
+
+echo "  Registry credentials updated"
+
+# Deploy from Docker image
+echo ""
+echo "Deploying from Docker image..."
+
+CAPTAIN_DEFINITION_JSON=$(jq -n \
+  --arg imageName "$IMAGE_REF" \
+  '{schemaVersion: 2, imageName: $imageName}')
+
+DEPLOY_PAYLOAD=$(jq -n \
+  --argjson captainDef "$CAPTAIN_DEFINITION_JSON" \
+  '{captainDefinitionContent: ($captainDef | tostring)}')
+
+# CapRover deploy can take longer than nginx's proxy_read_timeout (120s),
+# causing a 504 Gateway Timeout even though the deploy continues in the
+# background and succeeds. Use --max-time 300 to avoid curl hanging
+# indefinitely, and treat non-JSON responses as "deploy triggered".
+DEPLOY_RESPONSE=$(caprover_api_call "Deploy Docker image" \
+  curl -s -k --max-time 300 -X POST "$CAPROVER_URL/api/v2/user/apps/appData/$APP_NAME" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$DEPLOY_PAYLOAD") || true
+
+if ! echo "$DEPLOY_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "  Warning: CapRover returned a non-JSON response (likely 504 timeout)"
+  echo "  Response (first 5 lines):"
+  echo "$DEPLOY_RESPONSE" | head -5
+  echo ""
+  echo "  The deploy request was sent. CapRover processes deploys"
+  echo "  asynchronously, so the deployment likely continues in the"
+  echo "  background. The health check step will verify actual status."
+else
+  DEPLOY_STATUS=$(echo "$DEPLOY_RESPONSE" | jq -r '.status')
+  DEPLOY_DESC=$(echo "$DEPLOY_RESPONSE" | jq -r '.description // ""')
+
+  if [ "$DEPLOY_STATUS" != "100" ] && [ "$DEPLOY_STATUS" != "1000" ]; then
+    echo "  Error: Deployment failed"
+    echo "  Response: $DEPLOY_RESPONSE"
+    exit 1
+  fi
+
+  echo "  Deployment triggered successfully"
+fi
+
+echo ""
+echo "========================================="
+echo "Deploy from GHCR complete"
+echo "========================================="
+echo "Image: $IMAGE_REF"
+echo "Next: Health check will verify container started"
+echo "========================================="

--- a/plugins/deploy/scripts/setup-ghcr-package.sh
+++ b/plugins/deploy/scripts/setup-ghcr-package.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+set -e
+
+# Setup GHCR Package Permissions
+# Configures GitHub Container Registry package with proper permissions
+#
+# Usage:
+#   ./setup-ghcr-package.sh \
+#     --package-name <name> \
+#     --github-owner <owner> \
+#     --github-token <token> \
+#     --repository <repo>
+
+# Parse arguments
+PACKAGE_NAME=""
+GITHUB_OWNER="raajkumars"
+GITHUB_TOKEN=""
+REPOSITORY="qwickapps"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --package-name)
+      PACKAGE_NAME="$2"
+      shift 2
+      ;;
+    --github-owner)
+      GITHUB_OWNER="$2"
+      shift 2
+      ;;
+    --github-token)
+      GITHUB_TOKEN="$2"
+      shift 2
+      ;;
+    --repository)
+      REPOSITORY="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "$PACKAGE_NAME" ] || [ -z "$GITHUB_TOKEN" ]; then
+  echo "Error: Missing required arguments"
+  echo "Usage: $0 --package-name <name> --github-token <token>"
+  exit 1
+fi
+
+echo "========================================="
+echo "Setup GHCR Package Permissions"
+echo "========================================="
+echo "Package: $PACKAGE_NAME"
+echo "Owner: $GITHUB_OWNER"
+echo "Repository: $REPOSITORY"
+echo "========================================="
+
+# GitHub API base URL
+API_URL="https://api.github.com"
+PACKAGE_URL="$API_URL/user/packages/container/$PACKAGE_NAME"
+
+echo ""
+echo "Checking if package exists..."
+PACKAGE_CHECK=$(curl -s -w "%{http_code}" -o /tmp/ghcr-package-check.json \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "$PACKAGE_URL")
+
+if [ "$PACKAGE_CHECK" = "404" ]; then
+  echo "  Package does not exist yet - will be created on first push"
+  echo "  Note: Permissions will be configured after first image push"
+  echo ""
+  echo "========================================="
+  echo "Next Steps"
+  echo "========================================="
+  echo "1. Push first Docker image to ghcr.io/$GITHUB_OWNER/$PACKAGE_NAME"
+  echo "2. Run this script again to configure permissions"
+  echo "========================================="
+  exit 0
+elif [ "$PACKAGE_CHECK" != "200" ]; then
+  echo "  Error: Failed to check package (HTTP $PACKAGE_CHECK)"
+  cat /tmp/ghcr-package-check.json
+  exit 1
+fi
+
+echo "  ✓ Package exists"
+
+echo ""
+echo "Configuring repository access..."
+
+# Grant repository write access to the package
+REPO_ACCESS_RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X PUT \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "$PACKAGE_URL/repositories/$REPOSITORY" \
+  -d '{"permission":"write"}')
+
+HTTP_CODE=$(echo "$REPO_ACCESS_RESPONSE" | tail -n1)
+RESPONSE_BODY=$(echo "$REPO_ACCESS_RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" = "204" ] || [ "$HTTP_CODE" = "200" ]; then
+  echo "  ✓ Repository access configured (write)"
+else
+  echo "  Warning: Failed to configure repository access (HTTP $HTTP_CODE)"
+  echo "$RESPONSE_BODY" | jq '.' 2>/dev/null || echo "$RESPONSE_BODY"
+fi
+
+echo ""
+echo "Configuring package visibility..."
+
+# Ensure package is private
+VISIBILITY_RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X PATCH \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "$PACKAGE_URL" \
+  -d '{"visibility":"private"}')
+
+HTTP_CODE=$(echo "$VISIBILITY_RESPONSE" | tail -n1)
+RESPONSE_BODY=$(echo "$VISIBILITY_RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" = "200" ]; then
+  echo "  ✓ Package visibility set to private"
+else
+  echo "  Warning: Failed to set visibility (HTTP $HTTP_CODE)"
+  echo "$RESPONSE_BODY" | jq '.' 2>/dev/null || echo "$RESPONSE_BODY"
+fi
+
+echo ""
+echo "Verifying owner has admin access..."
+
+# Get current package details
+PACKAGE_DETAILS=$(curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "$PACKAGE_URL")
+
+OWNER_ACCESS=$(echo "$PACKAGE_DETAILS" | jq -r '.owner.login')
+if [ "$OWNER_ACCESS" = "$GITHUB_OWNER" ]; then
+  echo "  ✓ Owner has admin access"
+else
+  echo "  Warning: Owner mismatch (expected: $GITHUB_OWNER, got: $OWNER_ACCESS)"
+fi
+
+echo ""
+echo "========================================="
+echo "✓ GHCR Package Setup Complete"
+echo "========================================="
+echo ""
+echo "Package Details:"
+echo "  URL: https://github.com/users/$GITHUB_OWNER/packages/container/$PACKAGE_NAME"
+echo "  Registry: ghcr.io/$GITHUB_OWNER/$PACKAGE_NAME"
+echo "  Visibility: private"
+echo "  Repository Access: $REPOSITORY (write)"
+echo ""
+echo "Next Steps:"
+echo "1. Verify settings: https://github.com/users/$GITHUB_OWNER/packages/container/$PACKAGE_NAME/settings"
+echo "2. Push Docker image: docker push ghcr.io/$GITHUB_OWNER/$PACKAGE_NAME:tag"
+echo "3. Deploy to CapRover using deploy-from-ghcr.sh"
+echo ""

--- a/plugins/deploy/scripts/setup-qwickway-route.sh
+++ b/plugins/deploy/scripts/setup-qwickway-route.sh
@@ -1,0 +1,452 @@
+#!/bin/bash
+set -e
+
+# Setup QwickWay Route Script
+# Provisions a QwickWay gateway app on a CapRover instance (route.qwickforge.com).
+# QwickWay is a reverse proxy that routes traffic from one CapRover server to apps
+# on other CapRover servers via external URLs.
+#
+# Architecture:
+#   route.qwickforge.com  - QwickWay gateway apps (public-facing)
+#   app.qwickforge.com    - Prod/UAT apps (OCI_MAIN)
+#   dev.qwickforge.com    - Dev apps (OCI_DEV)
+#
+# The gateway uses external URLs for TARGET_APP because the servers are on
+# separate Docker swarms and cannot communicate via internal hostnames.
+#
+# Usage:
+#   ./setup-qwickway-route.sh \
+#     --gateway-app-name <name> \
+#     --target-app-url <url> \
+#     --route-caprover-url <url> \
+#     --route-caprover-password <password> \
+#     --github-token <token> \
+#     [--domain <custom-domain>] \
+#     [--health-check-path <path>] \
+#     [--github-owner <owner>]
+
+# Retry wrapper for CapRover API calls
+# Usage: caprover_api_call <description> <curl_command...>
+caprover_api_call() {
+  local description="$1"
+  shift
+  local max_retries=5
+  local retry_delay=10
+  local attempt=1
+
+  while [ $attempt -le $max_retries ]; do
+    echo "  Attempt $attempt/$max_retries: $description" >&2
+
+    # Execute curl command and capture response
+    local response
+    response=$("$@")
+
+    # Check if CapRover is busy
+    if echo "$response" | grep -iq "another operation.*in progress\|operation.*still in progress\|please wait"; then
+      if [ $attempt -lt $max_retries ]; then
+        echo "  CapRover is busy with another operation" >&2
+        echo "  Waiting ${retry_delay}s before retry..." >&2
+        sleep $retry_delay
+
+        # Exponential backoff: double the delay for next retry (max 60s)
+        retry_delay=$((retry_delay * 2))
+        if [ $retry_delay -gt 60 ]; then
+          retry_delay=60
+        fi
+
+        attempt=$((attempt + 1))
+        continue
+      else
+        echo "  CapRover still busy after $max_retries attempts" >&2
+        echo "  Response: $response" >&2
+        return 1
+      fi
+    fi
+
+    # Success - return response (to stdout only)
+    echo "$response"
+    return 0
+  done
+
+  # Should never reach here, but just in case
+  return 1
+}
+
+# Parse arguments
+GATEWAY_APP_NAME=""
+TARGET_APP_URL=""
+ROUTE_CAPROVER_URL=""
+ROUTE_CAPROVER_PASSWORD=""
+DOMAIN=""
+HEALTH_CHECK_PATH="/health"
+GITHUB_TOKEN=""
+GITHUB_OWNER="qwickapps"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --gateway-app-name)
+      GATEWAY_APP_NAME="$2"
+      shift 2
+      ;;
+    --target-app-url)
+      TARGET_APP_URL="$2"
+      shift 2
+      ;;
+    --route-caprover-url)
+      ROUTE_CAPROVER_URL="$2"
+      shift 2
+      ;;
+    --route-caprover-password)
+      ROUTE_CAPROVER_PASSWORD="$2"
+      shift 2
+      ;;
+    --domain)
+      DOMAIN="$2"
+      shift 2
+      ;;
+    --health-check-path)
+      HEALTH_CHECK_PATH="$2"
+      shift 2
+      ;;
+    --github-token)
+      GITHUB_TOKEN="$2"
+      shift 2
+      ;;
+    --github-owner)
+      GITHUB_OWNER="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "$GATEWAY_APP_NAME" ] || [ -z "$TARGET_APP_URL" ] || [ -z "$ROUTE_CAPROVER_URL" ] || [ -z "$ROUTE_CAPROVER_PASSWORD" ] || [ -z "$GITHUB_TOKEN" ]; then
+  echo "Error: Missing required arguments"
+  echo "Usage: $0 --gateway-app-name <name> --target-app-url <url> --route-caprover-url <url> --route-caprover-password <password> --github-token <token>"
+  exit 1
+fi
+
+QWICKWAY_IMAGE="ghcr.io/$GITHUB_OWNER/qwickway:latest"
+
+echo "========================================="
+echo "Setup QwickWay Route"
+echo "========================================="
+echo "Gateway App: $GATEWAY_APP_NAME"
+echo "Target URL:  $TARGET_APP_URL"
+echo "Route CapRover: $ROUTE_CAPROVER_URL"
+echo "Image: $QWICKWAY_IMAGE"
+echo "Health Check Path: $HEALTH_CHECK_PATH"
+if [ -n "$DOMAIN" ]; then
+  echo "Domain: $DOMAIN"
+fi
+echo "========================================="
+
+# Step 1: Authenticate with route CapRover instance
+echo ""
+echo "Authenticating with route CapRover..."
+LOGIN_RESPONSE=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg pw "$ROUTE_CAPROVER_PASSWORD" '{password: $pw}')")
+
+if ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: Route CapRover returned non-JSON response (server may be down)"
+  exit 1
+fi
+
+LOGIN_STATUS=$(echo "$LOGIN_RESPONSE" | jq -r '.status')
+if [ "$LOGIN_STATUS" != "100" ]; then
+  echo "Error: Authentication failed with route CapRover (status: $LOGIN_STATUS)"
+  exit 1
+fi
+
+TOKEN=$(echo "$LOGIN_RESPONSE" | jq -r '.data.token')
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "  Error: Failed to extract auth token from route CapRover"
+  exit 1
+fi
+
+echo "  Authenticated"
+
+# Step 2: Register gateway app (idempotent - handles already exists)
+echo ""
+echo "Registering gateway app..."
+CREATE_RESPONSE=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions/register" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$(jq -n --arg name "$GATEWAY_APP_NAME" '{appName: $name, hasPersistentData: false}')")
+
+if ! echo "$CREATE_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "  Error: Invalid JSON response from CapRover:"
+  echo "$CREATE_RESPONSE"
+  exit 1
+fi
+
+CREATE_STATUS=$(echo "$CREATE_RESPONSE" | jq -r '.status')
+APP_ALREADY_EXISTS=false
+
+if [ "$CREATE_STATUS" = "100" ]; then
+  echo "  App registered"
+  APP_ALREADY_EXISTS=false
+elif [ "$CREATE_STATUS" = "1901" ]; then
+  echo "  App already exists"
+  APP_ALREADY_EXISTS=true
+else
+  DESC=$(echo "$CREATE_RESPONSE" | jq -r '.description')
+  if echo "$DESC" | grep -q "already exists"; then
+    echo "  App already exists"
+    APP_ALREADY_EXISTS=true
+  else
+    echo "  Warning: Unexpected response: $DESC"
+    APP_ALREADY_EXISTS=false
+  fi
+fi
+
+# Step 3: Read-then-write: fetch current app definition, merge settings
+echo ""
+echo "Fetching current app definition..."
+ALL_DEFS=$(curl -s -k -X GET "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $TOKEN")
+
+CURRENT_DEF=$(echo "$ALL_DEFS" | jq --arg name "$GATEWAY_APP_NAME" '.data.appDefinitions[] | select(.appName == $name)')
+
+if [ -z "$CURRENT_DEF" ] || [ "$CURRENT_DEF" = "null" ]; then
+  echo "  Error: Could not fetch app definition for $GATEWAY_APP_NAME"
+  exit 1
+fi
+
+echo "  Fetched app definition"
+
+# Step 4: Set env vars and container port, merge into existing definition
+# TARGET_APP uses the external URL because the route and app servers are on
+# separate Docker swarms and cannot communicate via internal hostnames.
+echo ""
+echo "Configuring env vars and container port..."
+
+ENV_VARS=$(jq -n \
+  --arg targetApp "$TARGET_APP_URL" \
+  --arg healthPath "$HEALTH_CHECK_PATH" \
+  '[{key: "TARGET_APP", value: $targetApp}, {key: "HEALTH_CHECK_PATH", value: $healthPath}]')
+
+MERGED=$(echo "$CURRENT_DEF" | jq \
+  --argjson envVars "$ENV_VARS" \
+  --argjson port 80 \
+  '.envVars = $envVars | .containerHttpPort = $port | .instanceCount = 1 | .forceSsl = true | .websocketSupport = true')
+
+echo "  TARGET_APP=$TARGET_APP_URL"
+echo "  HEALTH_CHECK_PATH=$HEALTH_CHECK_PATH"
+echo "  Container port: 80"
+
+UPDATE_RESPONSE=$(caprover_api_call "Update app definition" \
+  curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions/update" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$MERGED")
+
+UPDATE_STATUS=$(echo "$UPDATE_RESPONSE" | jq -r '.status')
+
+if [ "$UPDATE_STATUS" = "100" ] || [ "$UPDATE_STATUS" = "1000" ]; then
+  echo "  App definition updated"
+else
+  echo "  Warning: Update response: $(echo "$UPDATE_RESPONSE" | jq -r '.description')"
+fi
+
+# Step 5: Refresh GHCR registry credentials on the route CapRover instance.
+# Stale entries from prior runs cause Internal Server Errors on deploy.
+echo ""
+echo "Refreshing GHCR registry credentials..."
+
+REGISTRIES_RESPONSE=$(curl -s -k -X GET "$ROUTE_CAPROVER_URL/api/v2/user/registries" \
+  -H "x-captain-auth: $TOKEN")
+
+# Delete all existing ghcr.io registry entries (may be multiple stale ones)
+EXISTING_IDS=$(echo "$REGISTRIES_RESPONSE" | jq -r '.data.registries[] | select(.registryDomain == "ghcr.io") | .id' 2>/dev/null || true)
+
+# Delete stale entries - log results instead of suppressing
+if [ -n "$EXISTING_IDS" ]; then
+  ENTRY_COUNT=$(echo "$EXISTING_IDS" | wc -l | tr -d ' ')
+  echo "  Found $ENTRY_COUNT existing ghcr.io entry/entries - removing stale credentials"
+  while IFS= read -r registry_id; do
+    [ -z "$registry_id" ] && continue
+    DELETE_RESP=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/registries/delete" \
+      -H "Content-Type: application/json" \
+      -H "x-captain-auth: $TOKEN" \
+      -d "$(jq -n --arg id "$registry_id" '{id: $id}')")
+    DELETE_ST=$(echo "$DELETE_RESP" | jq -r '.status' 2>/dev/null || echo "unknown")
+    if [ "$DELETE_ST" != "100" ]; then
+      echo "  Warning: Failed to delete registry entry $registry_id (status: $DELETE_ST)"
+    fi
+  done <<< "$EXISTING_IDS"
+fi
+
+# Insert fresh credentials using jq for safe JSON
+REGISTRY_PAYLOAD=$(jq -n \
+  --arg user "x-access-token" \
+  --arg pass "$GITHUB_TOKEN" \
+  --arg domain "ghcr.io" \
+  '{registryUser: $user, registryPassword: $pass, registryDomain: $domain, registryImagePrefix: ""}')
+
+REGISTRY_RESPONSE=$(caprover_api_call "Insert GHCR registry" \
+  curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/registries/insert" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$REGISTRY_PAYLOAD")
+
+if ! echo "$REGISTRY_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "  Error: CapRover returned invalid JSON when adding credentials"
+  echo "  Response: $REGISTRY_RESPONSE"
+  exit 1
+fi
+
+REGISTRY_STATUS=$(echo "$REGISTRY_RESPONSE" | jq -r '.status')
+if [ "$REGISTRY_STATUS" != "100" ]; then
+  REGISTRY_DESC=$(echo "$REGISTRY_RESPONSE" | jq -r '.description // "Unknown error"')
+  echo "  Error: Failed to add registry credentials: $REGISTRY_DESC (status: $REGISTRY_STATUS)"
+  exit 1
+fi
+
+echo "  Registry credentials updated"
+
+# Step 6: Deploy ghcr.io/qwickapps/qwickway:latest from GHCR
+echo ""
+echo "Deploying QwickWay image..."
+
+CAPTAIN_DEFINITION_JSON=$(jq -n \
+  --arg imageName "$QWICKWAY_IMAGE" \
+  '{schemaVersion: 2, imageName: $imageName}')
+
+DEPLOY_PAYLOAD=$(jq -n \
+  --argjson captainDef "$CAPTAIN_DEFINITION_JSON" \
+  '{captainDefinitionContent: ($captainDef | tostring)}')
+
+# CapRover deploy can take longer than nginx's proxy_read_timeout (120s),
+# causing a 504 Gateway Timeout even though the deploy continues in the
+# background and succeeds. Use --max-time 300 to avoid curl hanging
+# indefinitely, and treat non-JSON responses as "deploy triggered".
+DEPLOY_RESPONSE=$(caprover_api_call "Deploy QwickWay image" \
+  curl -s -k --max-time 300 -X POST "$ROUTE_CAPROVER_URL/api/v2/user/apps/appData/$GATEWAY_APP_NAME" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$DEPLOY_PAYLOAD") || true
+
+if ! echo "$DEPLOY_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "  Warning: CapRover returned a non-JSON response (likely 504 timeout)"
+  echo "  Response (first 5 lines):"
+  echo "$DEPLOY_RESPONSE" | head -5
+  echo ""
+  echo "  The deploy request was sent. CapRover processes deploys"
+  echo "  asynchronously, so the deployment likely continues in the"
+  echo "  background. The health check step will verify actual status."
+else
+  DEPLOY_STATUS=$(echo "$DEPLOY_RESPONSE" | jq -r '.status')
+
+  if [ "$DEPLOY_STATUS" != "100" ] && [ "$DEPLOY_STATUS" != "1000" ]; then
+    echo "  Error: Deployment failed"
+    echo "  Response: $DEPLOY_RESPONSE"
+    exit 1
+  fi
+
+  echo "  Deployment triggered"
+fi
+
+# Step 7: Configure custom domain and SSL (only for new apps)
+# Existing apps keep their existing domain configuration.
+if [ "$APP_ALREADY_EXISTS" = "false" ] && [ -n "$DOMAIN" ]; then
+  echo ""
+  echo "Configuring custom domain: $DOMAIN..."
+
+  DOMAIN_RESPONSE=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions/customdomain" \
+    -H "Content-Type: application/json" \
+    -H "x-captain-auth: $TOKEN" \
+    -d "$(jq -n --arg app "$GATEWAY_APP_NAME" --arg dom "$DOMAIN" '{appName: $app, customDomain: $dom}')")
+
+  DOMAIN_STATUS=$(echo "$DOMAIN_RESPONSE" | jq -r '.status')
+  if [ "$DOMAIN_STATUS" = "100" ]; then
+    echo "  Domain added"
+  elif [ "$DOMAIN_STATUS" = "1902" ]; then
+    echo "  Domain already attached"
+  else
+    echo "  Warning: $(echo "$DOMAIN_RESPONSE" | jq -r '.description')"
+  fi
+
+  echo ""
+  echo "Enabling SSL for $DOMAIN..."
+  SSL_RESPONSE=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions/enablecustomdomainssl" \
+    -H "Content-Type: application/json" \
+    -H "x-captain-auth: $TOKEN" \
+    -d "$(jq -n --arg app "$GATEWAY_APP_NAME" --arg dom "$DOMAIN" '{appName: $app, customDomain: $dom}')")
+
+  SSL_STATUS=$(echo "$SSL_RESPONSE" | jq -r '.status')
+  if [ "$SSL_STATUS" = "100" ]; then
+    echo "  SSL enabled"
+  else
+    echo "  Warning: $(echo "$SSL_RESPONSE" | jq -r '.description')"
+  fi
+fi
+
+# Step 8: Validate gateway health
+# Wait for the container to start before checking. CapRover deploys are
+# asynchronous; allow up to 60s for the container to become reachable.
+echo ""
+echo "Validating gateway health..."
+
+# Determine the gateway base URL. Use the custom domain if provided,
+# otherwise derive the default CapRover subdomain URL.
+if [ -n "$DOMAIN" ]; then
+  GATEWAY_BASE_URL="https://$DOMAIN"
+else
+  # Strip trailing slash from ROUTE_CAPROVER_URL, then build subdomain URL.
+  # CapRover uses captain.<root-domain> as its panel URL.
+  # Apps are served at <app-name>.<root-domain>.
+  CAPROVER_HOST=$(echo "$ROUTE_CAPROVER_URL" | sed 's|https://||' | sed 's|http://||' | sed 's|/||g')
+  # Remove the "captain." prefix to get the root domain
+  ROOT_DOMAIN=$(echo "$CAPROVER_HOST" | sed 's/^captain\.//')
+  GATEWAY_BASE_URL="https://$GATEWAY_APP_NAME.$ROOT_DOMAIN"
+fi
+
+GATEWAY_HEALTH_URL="$GATEWAY_BASE_URL/gateway/health"
+MAX_WAIT=60
+WAIT_INTERVAL=5
+ELAPSED=0
+HEALTH_OK=false
+
+echo "  Health URL: $GATEWAY_HEALTH_URL"
+echo "  Waiting up to ${MAX_WAIT}s for container to start..."
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$GATEWAY_HEALTH_URL" 2>/dev/null || echo "000")
+
+  if [ "$HTTP_STATUS" = "200" ]; then
+    HEALTH_OK=true
+    break
+  fi
+
+  echo "  HTTP $HTTP_STATUS - waiting ${WAIT_INTERVAL}s (${ELAPSED}s elapsed)..."
+  sleep $WAIT_INTERVAL
+  ELAPSED=$((ELAPSED + WAIT_INTERVAL))
+done
+
+if [ "$HEALTH_OK" = "true" ]; then
+  echo "  Gateway health check passed (HTTP 200)"
+else
+  echo "  Warning: Gateway health check did not return 200 within ${MAX_WAIT}s"
+  echo "  Last HTTP status: $HTTP_STATUS"
+  echo "  The container may still be starting. Verify manually: curl $GATEWAY_HEALTH_URL"
+  exit 1
+fi
+
+echo ""
+echo "========================================="
+echo "QwickWay route setup complete"
+echo "========================================="
+echo "Gateway App:  $GATEWAY_APP_NAME"
+echo "Target URL:   $TARGET_APP_URL"
+echo "Gateway URL:  $GATEWAY_BASE_URL"
+echo "Health Check: $GATEWAY_HEALTH_URL"
+if [ -n "$DOMAIN" ]; then
+  echo "Domain:       $DOMAIN"
+fi
+echo "========================================="

--- a/plugins/deploy/scripts/validate-deployment-health.sh
+++ b/plugins/deploy/scripts/validate-deployment-health.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+set -e
+
+# Validate Deployment Health
+# Checks HTTP status AND scans logs for errors after deployment
+#
+# Usage:
+#   ./validate-deployment-health.sh \
+#     --app-name <name> \
+#     --caprover-url <url> \
+#     --caprover-password <password> \
+#     --app-url <url> \
+#     --health-path <path>
+
+# Parse arguments
+APP_NAME=""
+CAPROVER_URL=""
+CAPROVER_PASSWORD=""
+APP_URL=""
+HEALTH_PATH="/health"
+EXPECTED_VERSION=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --app-name)
+      APP_NAME="$2"
+      shift 2
+      ;;
+    --caprover-url)
+      CAPROVER_URL="$2"
+      shift 2
+      ;;
+    --caprover-password)
+      CAPROVER_PASSWORD="$2"
+      shift 2
+      ;;
+    --app-url)
+      APP_URL="$2"
+      shift 2
+      ;;
+    --health-path)
+      HEALTH_PATH="$2"
+      shift 2
+      ;;
+    --expected-version)
+      EXPECTED_VERSION="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "$APP_NAME" ] || [ -z "$CAPROVER_URL" ] || [ -z "$CAPROVER_PASSWORD" ] || [ -z "$APP_URL" ]; then
+  echo "Error: Missing required arguments"
+  echo "Usage: $0 --app-name <name> --caprover-url <url> --caprover-password <password> --app-url <url>"
+  exit 1
+fi
+
+echo "========================================="
+echo "Validate Deployment Health"
+echo "========================================="
+echo "App: $APP_NAME"
+echo "URL: $APP_URL"
+echo "Health: $HEALTH_PATH"
+echo "========================================="
+
+# Authenticate with CapRover
+echo ""
+echo "Authenticating with CapRover..."
+TOKEN=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"password\":\"$CAPROVER_PASSWORD\"}" | jq -r '.data.token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Error: Failed to authenticate"
+  exit 1
+fi
+
+echo "  ✓ Authenticated"
+
+# Step 1: Check HTTP status and version
+echo ""
+echo "Step 1: Checking HTTP status and version..."
+HEALTH_RESPONSE=$(curl -s "$APP_URL$HEALTH_PATH")
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL$HEALTH_PATH" || echo "000")
+
+if [ "$HTTP_STATUS" = "200" ]; then
+  echo "  ✓ HTTP 200 OK"
+
+  # Check deployed version if expected version was provided
+  if [ -n "$EXPECTED_VERSION" ]; then
+    DEPLOYED_VERSION=$(echo "$HEALTH_RESPONSE" | jq -r '.version // "unknown"')
+    echo "  Expected version: $EXPECTED_VERSION"
+    echo "  Deployed version: $DEPLOYED_VERSION"
+
+    if [ "$DEPLOYED_VERSION" = "$EXPECTED_VERSION" ]; then
+      echo "  ✓ Version matches"
+    elif [ "$DEPLOYED_VERSION" = "unknown" ]; then
+      echo "  ⚠️  Could not determine deployed version"
+    else
+      echo "  ✗ Version mismatch!"
+      echo ""
+      echo "VALIDATION FAILED: Deployed version ($DEPLOYED_VERSION) does not match expected version ($EXPECTED_VERSION)"
+      exit 1
+    fi
+  fi
+else
+  echo "  ✗ HTTP $HTTP_STATUS"
+  echo ""
+  echo "VALIDATION FAILED: Health check returned non-200 status"
+  exit 1
+fi
+
+# Step 2: Check recent logs for errors
+echo ""
+echo "Step 2: Checking application logs for errors..."
+
+# Get all logs from CapRover
+ALL_LOGS=$(curl -s -k -X GET "$CAPROVER_URL/api/v2/user/apps/appData/$APP_NAME/logs" \
+  -H "x-captain-auth: $TOKEN" | jq -r '.data.logs // ""')
+
+if [ -z "$ALL_LOGS" ]; then
+  echo "  Warning: Could not retrieve logs"
+else
+  # Get only the last 100 lines (most recent logs)
+  # This avoids false positives from old deployments
+  RECENT_LOGS=$(echo "$ALL_LOGS" | tail -n 100)
+
+  # Critical error patterns (more specific to avoid false positives)
+  CRITICAL_PATTERNS=(
+    "SyntaxError.*does not provide an export"
+    "Cannot find module"
+    "ENOENT.*required"
+    "FATAL"
+    "process.exit\(1\)"
+    "MODULE_NOT_FOUND"
+    "ERR_MODULE_NOT_FOUND"
+  )
+
+  # Deployment failure patterns
+  DEPLOY_PATTERNS=(
+    "Build has failed"
+    "Deploy failed"
+    "invalid reference format"
+    "Failed to pull image"
+    "unauthorized.*pull"
+  )
+
+  # Check for repeating critical errors (if it's real, it will repeat)
+  CRITICAL_FOUND=0
+  CRITICAL_DETAILS=""
+
+  for pattern in "${CRITICAL_PATTERNS[@]}"; do
+    COUNT=$(echo "$RECENT_LOGS" | grep -c "$pattern" || true)
+    if [ "$COUNT" -ge 2 ]; then
+      CRITICAL_FOUND=1
+      CRITICAL_DETAILS="$CRITICAL_DETAILS\n  - $pattern (repeated $COUNT times in last 100 lines)"
+    fi
+  done
+
+  # Check for deployment failure indicators
+  for pattern in "${DEPLOY_PATTERNS[@]}"; do
+    if echo "$RECENT_LOGS" | grep -q "$pattern"; then
+      CRITICAL_FOUND=1
+      CRITICAL_DETAILS="$CRITICAL_DETAILS\n  - $pattern (deployment failure)"
+    fi
+  done
+
+  # Check for positive health indicators (successful startup)
+  HEALTH_INDICATORS=(
+    "Server.*started"
+    "Listening on port"
+    "Gateway.*started"
+    "Application.*ready"
+  )
+
+  HEALTHY_START=0
+  for indicator in "${HEALTH_INDICATORS[@]}"; do
+    if echo "$RECENT_LOGS" | grep -iq "$indicator"; then
+      HEALTHY_START=1
+      break
+    fi
+  done
+
+  # Report findings
+  if [ $CRITICAL_FOUND -eq 1 ]; then
+    echo "  ✗ Critical errors detected in recent logs:"
+    echo -e "$CRITICAL_DETAILS"
+    echo ""
+    echo "Recent error context (last 30 lines):"
+    echo "$RECENT_LOGS" | tail -n 30
+    echo ""
+    echo "VALIDATION FAILED: Critical errors found in recent application logs"
+    exit 1
+  elif [ $HEALTHY_START -eq 1 ]; then
+    echo "  ✓ Application started successfully (found startup indicator)"
+  else
+    echo "  ⚠️  No critical errors, but no clear startup success indicator found"
+    echo "  Continuing with deployment (HTTP check passed)"
+  fi
+fi
+
+# Step 3: Check container status
+echo ""
+echo "Step 3: Checking container status..."
+
+APP_DATA=$(curl -s -k -X GET "$CAPROVER_URL/api/v2/user/apps/appData/$APP_NAME" \
+  -H "x-captain-auth: $TOKEN")
+
+IS_READY=$(echo "$APP_DATA" | jq -r '.data.isAppBuilding')
+INSTANCE_COUNT=$(echo "$APP_DATA" | jq -r '.data.instanceCount // 1')
+RUNNING_INSTANCES=$(echo "$APP_DATA" | jq -r '.data.versions[0].deployedInstances // 0')
+
+if [ "$IS_READY" = "false" ]; then
+  echo "  ✓ App build complete"
+else
+  echo "  Warning: App may still be building"
+fi
+
+# Default to safe values if CapRover returned non-numeric data
+[[ "$INSTANCE_COUNT" =~ ^[0-9]+$ ]] || INSTANCE_COUNT=1
+[[ "$RUNNING_INSTANCES" =~ ^[0-9]+$ ]] || RUNNING_INSTANCES=0
+
+echo "  Instance count: $INSTANCE_COUNT"
+echo "  Running instances: $RUNNING_INSTANCES"
+
+if [ "$RUNNING_INSTANCES" -lt "$INSTANCE_COUNT" ]; then
+  echo "  ✗ Not all instances running ($RUNNING_INSTANCES/$INSTANCE_COUNT)"
+  echo ""
+  echo "VALIDATION FAILED: Not all instances are running"
+  exit 1
+else
+  echo "  ✓ All instances running"
+fi
+
+echo ""
+echo "========================================="
+echo "✓ Deployment Health Validation PASSED"
+echo "========================================="
+echo "App: $APP_NAME"
+echo "Status: Healthy"
+echo "HTTP: $HTTP_STATUS"
+echo "Instances: $RUNNING_INSTANCES/$INSTANCE_COUNT"
+echo "Logs: Clean (no critical errors)"
+echo "========================================="

--- a/plugins/deploy/skills/provisioning/SKILL.md
+++ b/plugins/deploy/skills/provisioning/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: provisioning
+description: >
+  This skill should be used when setting up CapRover apps and QwickWay gateways
+  for deployment, when debugging provisioning issues, or when manually configuring
+  deployment infrastructure. Trigger phrases: "provision the app", "set up CapRover",
+  "configure the gateway", "create the app on CapRover", "set up QwickWay",
+  "deployment infrastructure".
+---
+
+# Provisioning
+
+Apply this skill when creating or configuring CapRover apps and QwickWay gateways. Follow each section relevant to the task. Verify API responses at every step — silent failures are the primary cause of provisioning issues.
+
+---
+
+## Architecture Overview
+
+The deployment infrastructure uses three CapRover servers:
+
+| Server | URL | Purpose |
+|--------|-----|---------|
+| OCI_MAIN | app.qwickforge.com | Hosts prod and uat apps |
+| OCI_DEV | dev.qwickforge.com | Hosts dev apps (per-commit) |
+| ROUTE | route.qwickforge.com | Hosts QwickWay gateway apps |
+
+Apps on OCI_MAIN and OCI_DEV are not publicly reachable via custom domains directly. The QwickWay gateway on ROUTE proxies inbound requests from custom domains to the apps. Gateways reference apps by their external CapRover URL, because apps and gateways run on separate Docker swarms and cannot communicate via internal hostnames.
+
+```
+Custom Domain (DNS)
+  |
+  v
+route.qwickforge.com  <-- QwickWay gateway app
+  |
+  |  TARGET_APP = https://<app-name>.app.qwickforge.com
+  v
+app.qwickforge.com    <-- App container
+```
+
+---
+
+## App Naming Conventions
+
+Name apps consistently. Do not deviate from these conventions.
+
+| Environment | App name (on app/dev server) | Gateway name (on route server) | Custom domain |
+|-------------|------------------------------|-------------------------------|---------------|
+| prod | `<NAME>` | `<NAME>` | example.com |
+| uat | `<NAME>-uat` | `<NAME>-uat` | uat.example.com |
+| dev | `<NAME>-<sha>` (7-char git SHA) | `<NAME>-dev` (single, always points to latest) | dev.example.com |
+
+The dev gateway (`<NAME>-dev`) is not recreated on every commit. It is created once and its `TARGET_APP` env var is updated to point to the latest dev app URL on each deployment.
+
+---
+
+## CapRover App Provisioning
+
+### Authentication
+
+All CapRover API calls require a bearer token obtained from the login endpoint.
+
+```bash
+TOKEN=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d '{"password":"<password>"}' | jq -r '.data.token')
+```
+
+Pass the token as the `x-captain-auth` header on subsequent requests.
+
+### Creating an App
+
+Use the `/api/v2/user/apps/appDefinitions/register` endpoint. This is the correct endpoint for app creation.
+
+```bash
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/register" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{"appName":"<name>","hasPersistentData":false}'
+```
+
+Check `response.status`. A value of `100` is success. Any other value is a failure, even if the HTTP status is 200.
+
+**Common mistake:** Using `/api/v2/user/apps/appData/<name>` for app creation. That endpoint is for deploying images to an existing app, not creating the app definition. Calling it on a non-existent app silently fails or returns a 404.
+
+### Read-Then-Write Pattern for App Configuration
+
+CapRover's app configuration API requires sending the complete app definition, not just the changed fields. Always read the current definition first, merge changes, then write back.
+
+```bash
+# Read current definition
+APP_DEF=$(curl -s -k "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $TOKEN" \
+  | jq '.data.appDefinitions[] | select(.appName == "<name>")')
+
+# Merge new values into the definition
+UPDATED_DEF=$(echo "$APP_DEF" | jq \
+  --arg port "3000" \
+  '.containerHttpPort = ($port | tonumber)')
+
+# Write back
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/update" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$UPDATED_DEF"
+```
+
+Skipping the read step causes all unspecified fields to revert to defaults, which can remove env vars, port mappings, and domain configuration.
+
+The `configure-caprover-app.sh` script in `${CLAUDE_PLUGIN_ROOT}/scripts/` implements this pattern with diff comparison to show what changed before writing.
+
+### Environment Variables
+
+Set environment variables by including them in the app definition update. Do not use a separate env var endpoint — the app definition is the source of truth.
+
+```json
+{
+  "envVars": [
+    { "key": "NODE_ENV", "value": "production" },
+    { "key": "PORT", "value": "3000" }
+  ]
+}
+```
+
+### Container Port
+
+Set `containerHttpPort` to match the port your application listens on. Mismatches between the configured port and the actual port produce 502 Bad Gateway errors.
+
+### SSL and Domain Configuration
+
+After creating an app, enable the custom domain and force SSL:
+
+```bash
+# Add custom domain
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/customdomain" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{"appName":"<name>","customDomain":"example.com"}'
+
+# Enable SSL (Let's Encrypt)
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/enablecustomdomainssl" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{"appName":"<name>","customDomain":"example.com"}'
+
+# Force HTTPS in the app definition
+# Set forceSsl: true in the app definition update
+```
+
+SSL provisioning requires DNS to be pointed at the server before calling `enablecustomdomainssl`. If DNS has not propagated, the Let's Encrypt challenge will fail.
+
+---
+
+## GHCR Registry Credentials
+
+CapRover must be configured with GHCR credentials before it can pull private images. Stale credentials from previous runs cause 500 Internal Server Errors during deploy.
+
+The correct approach:
+
+1. Delete all existing `ghcr.io` registry entries from CapRover.
+2. Insert fresh credentials with the current GitHub token.
+
+Do not attempt to update existing entries. Delete and re-insert.
+
+The `deploy-from-ghcr.sh` script in `${CLAUDE_PLUGIN_ROOT}/scripts/` implements this pattern automatically on every deploy.
+
+### Manual credential refresh
+
+```bash
+# List registries
+curl -s -k "$CAPROVER_URL/api/v2/user/registries" \
+  -H "x-captain-auth: $TOKEN" | jq '.data.registries'
+
+# Delete stale entry (repeat for each stale ID)
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/registries/delete" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{"id":"<registry-id>"}'
+
+# Insert fresh credentials
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/registries/insert" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{
+    "registryUser":"x-access-token",
+    "registryPassword":"<github-token>",
+    "registryDomain":"ghcr.io",
+    "registryImagePrefix":""
+  }'
+```
+
+---
+
+## QwickWay Gateway Setup
+
+A QwickWay gateway is a CapRover app running the QwickWay container. It proxies incoming requests to the target app. Gateways live on the ROUTE server, not on OCI_MAIN or OCI_DEV.
+
+### Creating a gateway
+
+1. Create a CapRover app on the ROUTE server using the provisioning steps above.
+2. Set two required environment variables in the app definition:
+   - `TARGET_APP`: The external HTTPS URL of the destination app (e.g., `https://myapp.app.qwickforge.com`)
+   - `HEALTH_CHECK_PATH`: The health check path of the destination app (e.g., `/health`)
+3. Configure the custom domain on the gateway app (not on the destination app).
+4. Enable SSL on the gateway custom domain.
+
+The `setup-qwickway-route.sh` script in `${CLAUDE_PLUGIN_ROOT}/scripts/` automates gateway creation and updates.
+
+### Updating a gateway's target
+
+For the dev gateway (`<NAME>-dev`), update `TARGET_APP` after each dev deployment to point to the new SHA-tagged app:
+
+```bash
+# Read current definition
+APP_DEF=$(curl -s -k "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $ROUTE_TOKEN" \
+  | jq '.data.appDefinitions[] | select(.appName == "<name>-dev")')
+
+# Update TARGET_APP
+UPDATED_DEF=$(echo "$APP_DEF" | jq \
+  --arg target "https://<name>-<new-sha>.dev.qwickforge.com" \
+  '(.envVars[] | select(.key == "TARGET_APP")).value = $target')
+
+# Write back
+curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions/update" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $ROUTE_TOKEN" \
+  -d "$UPDATED_DEF"
+```
+
+### Architecture note on TARGET_APP URLs
+
+TARGET_APP must use the external CapRover URL for the app (`https://<app>.app.qwickforge.com`), not an internal Docker network address. The ROUTE server and the OCI_MAIN/OCI_DEV servers are on separate Docker swarms and cannot reach each other via Docker internal networking.
+
+---
+
+## Provisioning Checklist
+
+Before marking provisioning complete:
+
+- [ ] App created with `/api/v2/user/apps/appDefinitions/register` (not `/appData/`)
+- [ ] App definition read before any configuration write
+- [ ] Container port matches the app's actual listening port
+- [ ] GHCR credentials refreshed (delete stale, insert fresh)
+- [ ] Environment variables set in the app definition
+- [ ] Custom domain added and DNS pointed at the server
+- [ ] SSL enabled on the custom domain
+- [ ] QwickWay gateway created on ROUTE server with correct TARGET_APP
+- [ ] Gateway custom domain configured and SSL enabled
+- [ ] First deployment verified with `validate-deployment-health.sh`
+
+---
+
+## Scripts Reference
+
+All scripts are located at `${CLAUDE_PLUGIN_ROOT}/scripts/` and are copied to `.github/scripts/` by `/setup_workflow`.
+
+| Script | Purpose |
+|--------|---------|
+| `configure-caprover-app.sh` | Create or update app definition with diff output |
+| `deploy-from-ghcr.sh` | Refresh GHCR credentials and deploy Docker image |
+| `validate-deployment-health.sh` | HTTP check, log scan, and container status check |
+| `setup-ghcr-package.sh` | Configure GHCR package visibility and repo access |
+| `setup-qwickway-route.sh` | Create or update QwickWay gateway on ROUTE server |
+| `cleanup-dev-builds.sh` | Delete old SHA-tagged dev apps, keep last N |
+
+All scripts accept `--flag value` arguments, use `jq` for JSON, and validate all API responses.

--- a/plugins/deploy/skills/troubleshooting/SKILL.md
+++ b/plugins/deploy/skills/troubleshooting/SKILL.md
@@ -1,0 +1,404 @@
+---
+name: troubleshooting
+description: >
+  This skill should be used when deployment fails, health checks don't pass,
+  apps don't start, gateway routing is broken, or any deployment-related error
+  occurs. Trigger phrases: "deploy failed", "health check failing", "app not
+  starting", "502 bad gateway", "deployment error", "CapRover error",
+  "container won't start", "can't pull image", "gateway not routing".
+---
+
+# Troubleshooting
+
+Follow this skill when a deployment fails or the deployed app is not behaving correctly. Work through each section that matches the observed symptom. Do not skip to fixes — diagnose first.
+
+---
+
+## Diagnostic Principle
+
+Every deployment failure has a specific root cause. Silent failures and misleading success messages are common in CapRover workflows. Gather evidence before acting.
+
+Check in order:
+1. CapRover API response — did the operation actually succeed?
+2. Application logs — did the container start and run without errors?
+3. HTTP health check — is the app responding?
+4. Gateway routing — is the custom domain reaching the app?
+
+---
+
+## Common Failures
+
+### 1. Wrong API Endpoint for App Creation
+
+**Symptom:** App creation returns 404, or the app does not appear in the CapRover dashboard after the workflow runs. The workflow may report success because the error was not checked.
+
+**Root cause:** The workflow calls `/api/v2/user/apps/appData/<name>` (the deploy endpoint) instead of `/api/v2/user/apps/appDefinitions/register` (the create endpoint). The deploy endpoint silently ignores requests for apps that do not exist.
+
+**Diagnosis:**
+
+```bash
+# Check if the app exists
+curl -s -k "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $TOKEN" \
+  | jq '.data.appDefinitions[] | select(.appName == "<app-name>") | .appName'
+```
+
+If nothing is returned, the app was never created.
+
+**Fix:** Use the correct endpoint.
+
+```bash
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/register" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{"appName":"<name>","hasPersistentData":false}'
+```
+
+Check that `response.status` is `100` before proceeding.
+
+---
+
+### 2. Health Check Exits 0 When App Is Down
+
+**Symptom:** The workflow reports the deployment as successful, but the app is not accessible. Requests to the app URL return errors. CapRover may show the app as deployed.
+
+**Root cause:** The health check step in the workflow uses a command that always exits 0 (success), regardless of whether the HTTP response was 200 or an error. Common patterns that silently swallow failures:
+- `curl` without `-f` or without checking `$?`
+- Exit code piped to `/dev/null`
+- Health check result stored in a variable but never evaluated
+
+**Diagnosis:**
+
+```bash
+# Run the health check manually and check the exit code
+curl -f -s "$APP_URL/health"
+echo "Exit code: $?"
+
+# Also check the HTTP status code explicitly
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL/health")
+echo "HTTP status: $HTTP_STATUS"
+```
+
+If the exit code is 0 but the status is not 200, the health check script is not failing correctly.
+
+**Fix:** Use `validate-deployment-health.sh` from `${CLAUDE_PLUGIN_ROOT}/scripts/`. It checks HTTP status, scans logs for critical errors, checks container status, and exits 1 on any failure.
+
+```bash
+.github/scripts/validate-deployment-health.sh \
+  --app-name "$APP_NAME" \
+  --caprover-url "$CAPROVER_URL" \
+  --caprover-password "$CAPROVER_PASSWORD" \
+  --app-url "https://$APP_DOMAIN" \
+  --health-path "/health"
+```
+
+---
+
+### 3. Errors Piped to /dev/null (Silent Failures)
+
+**Symptom:** No error output in the workflow logs, but the deployment does not work. Each step appears to succeed. The actual problem is invisible.
+
+**Root cause:** API responses or command output are redirected to `/dev/null`, or errors are suppressed with `|| true` without logging the failure. The workflow runs to completion even when each step fails.
+
+**Diagnosis:** Add explicit response logging to each CapRover API call:
+
+```bash
+RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/register" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{"appName":"<name>","hasPersistentData":false}')
+
+echo "Response: $RESPONSE"
+
+STATUS=$(echo "$RESPONSE" | jq -r '.status')
+if [ "$STATUS" != "100" ]; then
+  echo "Error: operation failed with status $STATUS"
+  exit 1
+fi
+```
+
+**Fix:** Audit every API call in the workflow. Every call must:
+- Capture the response body
+- Check `response.status` equals `100`
+- Exit non-zero if the check fails
+- Never pipe to `/dev/null` without logging
+
+The scripts in `${CLAUDE_PLUGIN_ROOT}/scripts/` apply this pattern consistently.
+
+---
+
+### 4. Missing QwickWay Gateway
+
+**Symptom:** The custom domain (e.g., myapp.example.com) returns 404 or cannot be reached, but the app itself is healthy when accessed via its CapRover subdomain (e.g., `https://myapp.app.qwickforge.com`).
+
+**Root cause:** No QwickWay gateway app exists on the ROUTE server for this domain, or the gateway exists but `TARGET_APP` points to the wrong URL.
+
+**Diagnosis:**
+
+```bash
+# Authenticate with ROUTE server
+ROUTE_TOKEN=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d '{"password":"<route-password>"}' | jq -r '.data.token')
+
+# Check if gateway app exists
+curl -s -k "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $ROUTE_TOKEN" \
+  | jq '.data.appDefinitions[] | select(.appName == "<name>") | {appName, envVars}'
+```
+
+Check that:
+- The gateway app exists on ROUTE
+- `TARGET_APP` is set to `https://<app-name>.app.qwickforge.com` (external URL, not internal)
+- The custom domain is configured on the gateway (not on the app itself)
+- DNS points the custom domain at the ROUTE server
+
+**Fix:** Create or update the gateway using `setup-qwickway-route.sh` from `${CLAUDE_PLUGIN_ROOT}/scripts/`.
+
+---
+
+### 5. Missing Environments
+
+**Symptom:** Deployments work for one environment but not others. For example, dev deploys succeed but prod does not, or UAT was never set up.
+
+**Root cause:** The workflow only provisions one environment. The app and gateway creation steps were run once and not applied to all environments.
+
+**Diagnosis:** Check which apps exist on each server.
+
+```bash
+# OCI_MAIN (prod + uat)
+curl -s -k "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $TOKEN" \
+  | jq '[.data.appDefinitions[].appName]'
+
+# OCI_DEV (dev)
+curl -s -k "$OCI_DEV_CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $OCI_DEV_TOKEN" \
+  | jq '[.data.appDefinitions[].appName]'
+
+# ROUTE (gateways)
+curl -s -k "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $ROUTE_TOKEN" \
+  | jq '[.data.appDefinitions[].appName]'
+```
+
+**Fix:** Run the provisioning steps for each missing environment. The `/setup_workflow` command generates workflows that provision all three environments.
+
+---
+
+### 6. GHCR Registry Credentials Stale
+
+**Symptom:** CapRover returns a 500 Internal Server Error or "unauthorized" during the deploy step. The image exists in GHCR but CapRover cannot pull it.
+
+**Root cause:** CapRover caches GHCR credentials from a previous deployment. When the GitHub token rotates (e.g., it was a short-lived Actions token from a prior run), the cached credentials are no longer valid. CapRover does not automatically detect this and returns a server error.
+
+**Diagnosis:**
+
+```bash
+# List current registries in CapRover
+curl -s -k "$CAPROVER_URL/api/v2/user/registries" \
+  -H "x-captain-auth: $TOKEN" \
+  | jq '.data.registries[] | select(.registryDomain == "ghcr.io") | {id, registryUser}'
+```
+
+If multiple ghcr.io entries appear, they are stale duplicates.
+
+**Fix:** Delete all existing ghcr.io entries and insert fresh credentials. The `deploy-from-ghcr.sh` script in `${CLAUDE_PLUGIN_ROOT}/scripts/` does this automatically. To fix manually:
+
+```bash
+# Delete stale entries (repeat for each ID)
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/registries/delete" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{"id":"<registry-id>"}'
+
+# Insert fresh credentials
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/registries/insert" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d '{
+    "registryUser":"x-access-token",
+    "registryPassword":"<current-github-token>",
+    "registryDomain":"ghcr.io",
+    "registryImagePrefix":""
+  }'
+```
+
+---
+
+### 7. Container Port Mismatch
+
+**Symptom:** The app is deployed and running, but requests return 502 Bad Gateway. The CapRover health check shows the container is up.
+
+**Root cause:** The `containerHttpPort` in the CapRover app definition does not match the port the application actually listens on. CapRover proxies traffic to the wrong port, which is not listening, and returns 502.
+
+**Diagnosis:**
+
+```bash
+# Check the configured port in the app definition
+curl -s -k "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $TOKEN" \
+  | jq '.data.appDefinitions[] | select(.appName == "<name>") | .containerHttpPort'
+
+# Check what port the app actually listens on
+# Look at the application's Dockerfile EXPOSE statement
+# Or check the app's port configuration (PORT env var, server.listen() call, etc.)
+```
+
+**Fix:** Update the app definition to match the actual listening port.
+
+```bash
+APP_DEF=$(curl -s -k "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $TOKEN" \
+  | jq '.data.appDefinitions[] | select(.appName == "<name>")')
+
+UPDATED_DEF=$(echo "$APP_DEF" | jq \
+  --argjson port 3000 \
+  '.containerHttpPort = $port')
+
+curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/update" \
+  -H "Content-Type: application/json" \
+  -H "x-captain-auth: $TOKEN" \
+  -d "$UPDATED_DEF"
+```
+
+Redeploy after updating the port.
+
+---
+
+### 8. Image Not Found
+
+**Symptom:** The deploy step fails with "invalid reference format", "manifest unknown", or "not found". The image cannot be pulled.
+
+**Root cause:** The image reference in the deploy payload points to an image that does not exist in GHCR. Common causes:
+- The build job failed or was skipped, so the image was never pushed
+- The image tag in the deploy step does not match the tag used during build
+- The image was pushed to the wrong GHCR organization or repo
+
+**Diagnosis:**
+
+```bash
+# Check what image reference the deploy step is using
+# Look at the workflow log output for the deploy step
+
+# Verify the image exists in GHCR
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/orgs/<owner>/packages/container/<package>/versions" \
+  | jq '.[0:5] | [.[] | {id, name: .metadata.container.tags}]'
+```
+
+Also confirm the build job log shows "Successfully pushed" before the deploy job runs.
+
+**Fix:**
+- Verify the build job succeeded and pushed the image.
+- Confirm the image tag in the deploy step matches the tag used in the build step. Both should reference `${{ github.sha }}` for consistency.
+- Confirm the GHCR organization in the image reference matches the actual package location.
+
+---
+
+## Checking CapRover Logs via API
+
+Retrieve application logs to diagnose startup errors without accessing the CapRover dashboard.
+
+```bash
+# Get logs for an app
+LOGS=$(curl -s -k "$CAPROVER_URL/api/v2/user/apps/appData/$APP_NAME/logs" \
+  -H "x-captain-auth: $TOKEN" \
+  | jq -r '.data.logs // "No logs returned"')
+
+echo "$LOGS" | tail -n 50
+```
+
+Look for:
+- `Cannot find module` — missing dependency or wrong build artifact
+- `MODULE_NOT_FOUND` / `ERR_MODULE_NOT_FOUND` — ESM/CJS resolution error
+- `ENOENT` — missing file at expected path
+- `SyntaxError` — broken JavaScript/TypeScript in the deployed bundle
+- `FATAL` — application-level fatal error
+- `process.exit(1)` — intentional shutdown
+- `Build has failed` — CapRover-level build error
+- `invalid reference format` — bad image reference
+- `unauthorized` — registry authentication failure
+
+Startup success indicators:
+- `Server started`
+- `Listening on port`
+- `Gateway started`
+- `Application ready`
+
+If none of the startup indicators appear and there are no fatal errors, the app may still be building. Wait 30 seconds and check again.
+
+---
+
+## Verifying Gateway Routing
+
+After confirming the app is healthy on its CapRover subdomain, verify the gateway is routing correctly.
+
+```bash
+# Check app health directly (bypasses gateway)
+curl -f "https://<app-name>.app.qwickforge.com/health"
+
+# Check via custom domain (through gateway)
+curl -f "https://myapp.example.com/health"
+
+# Check gateway TARGET_APP configuration
+ROUTE_TOKEN=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/login" \
+  -H "Content-Type: application/json" \
+  -d '{"password":"<route-password>"}' | jq -r '.data.token')
+
+curl -s -k "$ROUTE_CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+  -H "x-captain-auth: $ROUTE_TOKEN" \
+  | jq '.data.appDefinitions[] | select(.appName == "<gateway-name>") | .envVars'
+```
+
+Confirm `TARGET_APP` is the external CapRover URL of the app, not an internal address.
+
+---
+
+## Manual Rollback
+
+To roll back to a previous deployment, redeploy the previous image tag.
+
+```bash
+# Find the previous image tag (use the git SHA of the last known-good commit)
+PREVIOUS_SHA=abc1234
+
+# Redeploy
+.github/scripts/deploy-from-ghcr.sh \
+  --app-name "$APP_NAME" \
+  --image-ref "ghcr.io/<owner>/<image>:$PREVIOUS_SHA" \
+  --caprover-url "$CAPROVER_URL" \
+  --caprover-password "$CAPROVER_PASSWORD" \
+  --github-token "$GITHUB_TOKEN" \
+  --github-owner "<owner>"
+
+# Verify
+.github/scripts/validate-deployment-health.sh \
+  --app-name "$APP_NAME" \
+  --caprover-url "$CAPROVER_URL" \
+  --caprover-password "$CAPROVER_PASSWORD" \
+  --app-url "https://$APP_DOMAIN" \
+  --health-path "/health"
+```
+
+Images are retained in GHCR as long as the package is not cleaned up. Identify the correct SHA from the git log or the GHCR package version list before rolling back.
+
+---
+
+## Troubleshooting Checklist
+
+Work through this list when a deployment is broken:
+
+- [ ] Checked CapRover API response status for each step (must be `100`)
+- [ ] Verified app exists on the correct CapRover server
+- [ ] Ran `validate-deployment-health.sh` and reviewed its output
+- [ ] Checked application logs via CapRover API for startup errors
+- [ ] Confirmed `containerHttpPort` matches the app's actual listening port
+- [ ] Confirmed GHCR credentials are fresh (delete stale, insert current)
+- [ ] Confirmed image reference matches the tag used during build
+- [ ] Confirmed gateway exists on ROUTE server with correct `TARGET_APP`
+- [ ] Confirmed custom domain DNS points to the correct server
+- [ ] Confirmed SSL is enabled on the custom domain
+
+If all items pass and the app is still not working, retrieve the full application logs and inspect the last 100 lines for any repeated error pattern.

--- a/plugins/deploy/templates/deploy-monorepo-product.yml
+++ b/plugins/deploy/templates/deploy-monorepo-product.yml
@@ -1,0 +1,266 @@
+name: Deploy __PRODUCT_NAME__
+
+on:
+  push:
+    branches: [main, dev]
+    tags: ['__APP_NAME__-v*']
+    paths:
+      - '__CLIENT_PATH__/**'
+      - 'packages/**'
+      - '.github/workflows/deploy-__PRODUCT_NAME__.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options: [dev, uat, prod]
+        default: dev
+
+# Cancel duplicate builds for the same branch; deploys queue via caprover concurrency
+concurrency:
+  group: deploy-__PRODUCT_NAME__-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        shell: zsh {0}
+    outputs:
+      image_ref: ${{ steps.version.outputs.image_ref }}
+      image_tag: ${{ steps.version.outputs.tag }}
+      environment: ${{ steps.env.outputs.environment }}
+      app_name: ${{ steps.env.outputs.app_name }}
+      app_url: ${{ steps.env.outputs.app_url }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve environment
+        id: env
+        run: |
+          source ~/.zshrc
+
+          # Determine environment from trigger source
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ENVIRONMENT="${{ inputs.environment }}"
+          elif [[ "${{ github.ref }}" == refs/tags/__APP_NAME__-v* ]]; then
+            ENVIRONMENT="prod"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            ENVIRONMENT="uat"
+          else
+            ENVIRONMENT="dev"
+          fi
+
+          # Derive app name and URL from environment
+          case "$ENVIRONMENT" in
+            prod)
+              APP_NAME="__APP_NAME__"
+              APP_URL="https://__PROD_DOMAIN__"
+              ;;
+            uat)
+              APP_NAME="__APP_NAME__-uat"
+              APP_URL="https://__UAT_DOMAIN__"
+              ;;
+            *)
+              APP_NAME="__APP_NAME__-dev"
+              APP_URL="https://__DEV_DOMAIN__"
+              ;;
+          esac
+
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+          echo "app_url=$APP_URL" >> $GITHUB_OUTPUT
+
+      - name: Read version info
+        id: version
+        run: |
+          source ~/.zshrc
+          VERSION=$(node -p "require('./__CLIENT_PATH__/package.json').version")
+          PACKAGE_NAME="img-__APP_NAME__-${{ steps.env.outputs.environment }}"
+          TAG="${VERSION}.${GITHUB_RUN_NUMBER}"
+          IMAGE_REF="ghcr.io/__GITHUB_OWNER__/${PACKAGE_NAME}:${TAG}"
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "image_ref=$IMAGE_REF" >> $GITHUB_OUTPUT
+          echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Build workspace package
+        run: |
+          source ~/.zshrc
+          .github/scripts/build-workspace-package.sh __CLIENT_PATH__
+
+      - name: Configure Docker auth for GHCR
+        run: |
+          source ~/.zshrc
+          DOCKER_DIR="$RUNNER_TEMP/docker-config-${{ github.run_id }}"
+          mkdir -p "$DOCKER_DIR"
+          AUTH=$(echo -n "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" | base64)
+          echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$AUTH\"}}}" > "$DOCKER_DIR/config.json"
+          echo "DOCKER_CONFIG=$DOCKER_DIR" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        run: |
+          source ~/.zshrc
+          # Build from client directory (Dockerfile must exist at __CLIENT_PATH__/Dockerfile)
+          docker build \
+            --build-arg NODE_ENV=production \
+            -f __CLIENT_PATH__/Dockerfile \
+            -t ghcr.io/__GITHUB_OWNER__/${{ steps.version.outputs.package_name }}:${{ steps.version.outputs.tag }} \
+            -t ghcr.io/__GITHUB_OWNER__/${{ steps.version.outputs.package_name }}:latest \
+            __CLIENT_PATH__/
+
+          docker push ghcr.io/__GITHUB_OWNER__/${{ steps.version.outputs.package_name }}:${{ steps.version.outputs.tag }}
+          docker push ghcr.io/__GITHUB_OWNER__/${{ steps.version.outputs.package_name }}:latest
+
+      - name: Clean up Docker credentials
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/docker-config-${{ github.run_id }}"
+
+  deploy-app:
+    needs: build
+    runs-on: self-hosted
+    defaults:
+      run:
+        shell: zsh {0}
+    concurrency:
+      group: caprover-deploy
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure CapRover app
+        env:
+          CAPROVER_URL: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_URL || secrets.CAPROVER_URL }}
+          CAPROVER_PASSWORD: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_PASSWORD || secrets.CAPROVER_PASSWORD }}
+          PAYLOAD_SECRET: ${{ secrets.__APP_NAME___PAYLOAD_SECRET }}
+        run: |
+          source ~/.zshrc
+
+          APP_NAME="${{ needs.build.outputs.app_name }}"
+          APP_URL="${{ needs.build.outputs.app_url }}"
+          ENVIRONMENT="${{ needs.build.outputs.environment }}"
+
+          cat > /tmp/app-env.txt << EOF
+NODE_ENV=production
+APP_ENV=${ENVIRONMENT}
+APP_NAME=${APP_NAME}
+NEXT_PUBLIC_SERVER_URL=${APP_URL}
+PAYLOAD_SECRET=${PAYLOAD_SECRET}
+EOF
+
+          .github/scripts/configure-caprover-app.sh \
+            --app-name "${APP_NAME}" \
+            --caprover-url "$CAPROVER_URL" \
+            --caprover-password "$CAPROVER_PASSWORD" \
+            --instance-count 1 \
+            --container-port __CONTAINER_PORT__ \
+            --force-ssl true \
+            --domains "$(echo ${APP_URL} | sed 's|https://||')" \
+            --env-file /tmp/app-env.txt
+
+      - name: Deploy from GHCR
+        env:
+          CAPROVER_URL: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_URL || secrets.CAPROVER_URL }}
+          CAPROVER_PASSWORD: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_PASSWORD || secrets.CAPROVER_PASSWORD }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+        run: |
+          source ~/.zshrc
+
+          .github/scripts/deploy-from-ghcr.sh \
+            --app-name "${{ needs.build.outputs.app_name }}" \
+            --image-ref "${{ needs.build.outputs.image_ref }}" \
+            --caprover-url "$CAPROVER_URL" \
+            --caprover-password "$CAPROVER_PASSWORD" \
+            --github-token "$GHCR_TOKEN" \
+            --github-owner __GITHUB_OWNER__
+
+      - name: Verify deployment
+        env:
+          CAPROVER_URL: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_URL || secrets.CAPROVER_URL }}
+          CAPROVER_PASSWORD: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_PASSWORD || secrets.CAPROVER_PASSWORD }}
+        run: |
+          source ~/.zshrc
+          echo "Waiting 30s for deployment to stabilize..."
+          sleep 30
+
+          .github/scripts/validate-deployment-health.sh \
+            --app-name "${{ needs.build.outputs.app_name }}" \
+            --caprover-url "$CAPROVER_URL" \
+            --caprover-password "$CAPROVER_PASSWORD" \
+            --app-url "${{ needs.build.outputs.app_url }}" \
+            --health-path __HEALTH_PATH__
+
+      - name: Deployment summary
+        if: always() && needs.build.result == 'success'
+        run: |
+          source ~/.zshrc
+          echo ""
+          echo "=========================================="
+          echo "Deployment Summary"
+          echo "=========================================="
+          echo ""
+          echo "__PRODUCT_NAME__ ${{ needs.build.outputs.environment }}: DEPLOYED"
+          echo "URL: ${{ needs.build.outputs.app_url }}"
+          echo "Image: ${{ needs.build.outputs.image_ref }}"
+          echo "Runner: ${{ runner.name }}"
+          echo ""
+          echo "=========================================="
+
+  deploy-gateway:
+    needs: [build, deploy-app]
+    runs-on: self-hosted
+    defaults:
+      run:
+        shell: zsh {0}
+    concurrency:
+      group: caprover-deploy
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set gateway variables
+        id: gateway
+        run: |
+          source ~/.zshrc
+          ENV="${{ needs.build.outputs.environment }}"
+
+          if [ "$ENV" = "prod" ]; then
+            GATEWAY_APP_NAME="__APP_NAME__"
+            TARGET_APP="https://${{ needs.build.outputs.app_name }}.app.qwickforge.com"
+          elif [ "$ENV" = "uat" ]; then
+            GATEWAY_APP_NAME="__APP_NAME__-uat"
+            TARGET_APP="https://${{ needs.build.outputs.app_name }}.app.qwickforge.com"
+          else
+            GATEWAY_APP_NAME="__APP_NAME__-dev"
+            TARGET_APP="https://${{ needs.build.outputs.app_name }}.dev.qwickforge.com"
+          fi
+
+          echo "gateway_app_name=${GATEWAY_APP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "target_app_url=${TARGET_APP}" >> "$GITHUB_OUTPUT"
+
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/*.sh
+
+      - name: Provision QwickWay gateway route
+        run: |
+          source ~/.zshrc
+          .github/scripts/setup-qwickway-route.sh \
+            --gateway-app-name "${{ steps.gateway.outputs.gateway_app_name }}" \
+            --target-app-url "${{ steps.gateway.outputs.target_app_url }}" \
+            --route-caprover-url "${{ secrets.ROUTE_CAPROVER_URL }}" \
+            --route-caprover-password "${{ secrets.ROUTE_CAPROVER_PASSWORD }}" \
+            --health-check-path "__HEALTH_PATH__" \
+            --github-token "${{ secrets.GHCR_PULL_TOKEN }}" \
+            --github-owner "__GITHUB_OWNER__"

--- a/plugins/deploy/templates/deploy-standalone.yml
+++ b/plugins/deploy/templates/deploy-standalone.yml
@@ -1,0 +1,237 @@
+name: Deploy __APP_NAME__
+
+on:
+  push:
+    branches: [main, dev]
+    tags: ['v*']
+    paths-ignore:
+      - '*.md'
+      - '.claude/**'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - dev
+          - uat
+          - prod
+        default: dev
+
+concurrency:
+  group: deploy-__APP_NAME__-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: __GITHUB_OWNER__
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.meta.outputs.image_ref }}
+      environment: ${{ steps.env.outputs.environment }}
+      app_name: ${{ steps.meta.outputs.app_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Determine environment
+        id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "environment=${{ inputs.environment }}" >> "$GITHUB_OUTPUT"
+          elif echo "${{ github.ref }}" | grep -q '^refs/tags/v'; then
+            echo "environment=prod" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "environment=uat" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=dev" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image tag
+        id: meta
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="${VERSION}.${{ github.run_number }}"
+          ENV="${{ steps.env.outputs.environment }}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.OWNER }}/__APP_NAME__-${ENV}:${TAG}"
+
+          # Derive app_name for CapRover
+          if [ "$ENV" = "prod" ]; then
+            APP_NAME="__APP_NAME__"
+          elif [ "$ENV" = "uat" ]; then
+            APP_NAME="__APP_NAME__-uat"
+          else
+            SHORT_SHA=$(echo "$GITHUB_SHA" | head -c 7)
+            APP_NAME="__APP_NAME__-${SHORT_SHA}"
+          fi
+
+          echo "image_ref=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "app_name=${APP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Image: ${IMAGE}"
+          echo "App: ${APP_NAME}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image_ref }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/__APP_NAME__-${{ steps.env.outputs.environment }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-app:
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: caprover-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/*.sh
+
+      - name: Derive app URL
+        id: vars
+        run: |
+          ENV="${{ needs.build.outputs.environment }}"
+          if [ "$ENV" = "prod" ]; then
+            echo "app_url=https://__PROD_DOMAIN__" >> "$GITHUB_OUTPUT"
+          elif [ "$ENV" = "uat" ]; then
+            echo "app_url=https://__UAT_DOMAIN__" >> "$GITHUB_OUTPUT"
+          else
+            SHORT_SHA=$(echo "$GITHUB_SHA" | head -c 7)
+            echo "app_url=https://__APP_NAME__-${SHORT_SHA}.dev.qwickforge.com" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write env file
+        run: |
+          cat > /tmp/app.env <<'EOF'
+NODE_ENV=production
+PORT=__CONTAINER_PORT__
+EOF
+
+      - name: Configure CapRover app
+        env:
+          CAPROVER_URL: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_URL || secrets.CAPROVER_URL }}
+          CAPROVER_PASSWORD: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_PASSWORD || secrets.CAPROVER_PASSWORD }}
+        run: |
+          .github/scripts/configure-caprover-app.sh \
+            --app-name "${{ needs.build.outputs.app_name }}" \
+            --caprover-url "$CAPROVER_URL" \
+            --caprover-password "$CAPROVER_PASSWORD" \
+            --container-port __CONTAINER_PORT__ \
+            --env-file /tmp/app.env
+
+      - name: Deploy from GHCR
+        env:
+          CAPROVER_URL: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_URL || secrets.CAPROVER_URL }}
+          CAPROVER_PASSWORD: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_PASSWORD || secrets.CAPROVER_PASSWORD }}
+        run: |
+          .github/scripts/deploy-from-ghcr.sh \
+            --app-name "${{ needs.build.outputs.app_name }}" \
+            --image-ref "${{ needs.build.outputs.image_ref }}" \
+            --caprover-url "$CAPROVER_URL" \
+            --caprover-password "$CAPROVER_PASSWORD" \
+            --github-token "${{ secrets.GHCR_PULL_TOKEN }}" \
+            --github-owner "${{ env.OWNER }}"
+
+      - name: Validate deployment health
+        env:
+          CAPROVER_URL: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_URL || secrets.CAPROVER_URL }}
+          CAPROVER_PASSWORD: ${{ needs.build.outputs.environment == 'dev' && secrets.OCI_DEV_CAPROVER_PASSWORD || secrets.CAPROVER_PASSWORD }}
+        run: |
+          .github/scripts/validate-deployment-health.sh \
+            --app-name "${{ needs.build.outputs.app_name }}" \
+            --caprover-url "$CAPROVER_URL" \
+            --caprover-password "$CAPROVER_PASSWORD" \
+            --app-url "${{ steps.vars.outputs.app_url }}" \
+            --health-path "__HEALTH_PATH__"
+
+  deploy-gateway:
+    needs: [build, deploy-app]
+    runs-on: ubuntu-latest
+    concurrency:
+      group: caprover-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/*.sh
+
+      - name: Set gateway variables
+        id: gateway
+        run: |
+          ENV="${{ needs.build.outputs.environment }}"
+          SHORT_SHA=$(echo "$GITHUB_SHA" | head -c 7)
+
+          # Gateway app name: dev always uses a stable name so the route
+          # points to the latest dev build rather than per-commit names.
+          if [ "$ENV" = "prod" ]; then
+            GATEWAY_APP_NAME="__APP_NAME__"
+            TARGET_APP="${{ needs.build.outputs.app_name }}.app.qwickforge.com"
+          elif [ "$ENV" = "uat" ]; then
+            GATEWAY_APP_NAME="__APP_NAME__-uat"
+            TARGET_APP="${{ needs.build.outputs.app_name }}.app.qwickforge.com"
+          else
+            GATEWAY_APP_NAME="__APP_NAME__-dev"
+            TARGET_APP="__APP_NAME__-${SHORT_SHA}.dev.qwickforge.com"
+          fi
+
+          echo "gateway_app_name=${GATEWAY_APP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "target_app_url=https://${TARGET_APP}" >> "$GITHUB_OUTPUT"
+
+      - name: Provision QwickWay route
+        run: |
+          .github/scripts/setup-qwickway-route.sh \
+            --gateway-app-name "${{ steps.gateway.outputs.gateway_app_name }}" \
+            --target-app-url "${{ steps.gateway.outputs.target_app_url }}" \
+            --route-caprover-url "${{ secrets.ROUTE_CAPROVER_URL }}" \
+            --route-caprover-password "${{ secrets.ROUTE_CAPROVER_PASSWORD }}" \
+            --health-check-path "__HEALTH_PATH__" \
+            --github-token "${{ secrets.GHCR_PULL_TOKEN }}" \
+            --github-owner "__GITHUB_OWNER__"
+
+  cleanup-dev:
+    needs: [build, deploy-gateway]
+    runs-on: ubuntu-latest
+    if: needs.build.outputs.environment == 'dev'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/*.sh
+
+      - name: Clean up old dev builds
+        run: |
+          .github/scripts/cleanup-dev-builds.sh \
+            --app-name-prefix "__APP_NAME__" \
+            --caprover-url "${{ secrets.OCI_DEV_CAPROVER_URL }}" \
+            --caprover-password "${{ secrets.OCI_DEV_CAPROVER_PASSWORD }}" \
+            --route-caprover-url "${{ secrets.ROUTE_CAPROVER_URL }}" \
+            --route-caprover-password "${{ secrets.ROUTE_CAPROVER_PASSWORD }}" \
+            --gateway-app-name "__APP_NAME__-dev"


### PR DESCRIPTION
## Summary

- Adds a `deploy` plugin that generates correct GitHub Actions deployment workflows for CapRover + QwickWay infrastructure
- Provides `/setup_workflow` command that detects repo type (standalone vs monorepo), collects config interactively, and generates workflow + scripts
- Includes 6 deployment scripts adapted from battle-tested qwickapps originals, with fixes for JSON injection, login validation, and env var parsing
- Adds provisioning and troubleshooting skills for CapRover app creation and deployment debugging

## What's included

**Command:** `/setup_workflow` - interactive workflow generator (Phase 1-6: detect, collect, generate, copy scripts, env example, summary)

**Scripts:**
- `configure-caprover-app.sh` - create/update app definition with env var diff
- `deploy-from-ghcr.sh` - refresh GHCR credentials and deploy Docker image
- `validate-deployment-health.sh` - HTTP check, log scan, container status
- `setup-qwickway-route.sh` - provision QwickWay gateway on route server
- `cleanup-dev-builds.sh` - delete old SHA-tagged dev apps, keep last N
- `setup-ghcr-package.sh` - configure GHCR package visibility

**Templates:** standalone and monorepo GitHub Actions workflow templates

**Skills:** provisioning guidance and troubleshooting runbook

## Fixes addressed

Fixes 5 bugs from broken qwickresume workflow:
1. Wrong API endpoint for app creation (`/appData/` vs `/appDefinitions/register`)
2. Health check exits 0 when app is down
3. Errors piped to `/dev/null` (silent failures)
4. No QwickWay gateway provisioned
5. Missing environment support (only one env configured)

## Test plan

- [ ] Run `/setup_workflow` on a standalone repo and verify generated workflow
- [ ] Run `/setup_workflow` on a monorepo and verify generated workflow
- [ ] Run `bash -n` on all 6 scripts (all pass)
- [ ] Deploy to dev environment and verify health check