### PR TITLE
fix: replace heredoc with printf in workflow templates

### DIFF
--- a/plugins/deploy/templates/deploy-monorepo-product.yml
+++ b/plugins/deploy/templates/deploy-monorepo-product.yml
@@ -150,13 +150,13 @@ jobs:
           APP_URL="${{ needs.build.outputs.app_url }}"
           ENVIRONMENT="${{ needs.build.outputs.environment }}"
 
-          cat > /tmp/app-env.txt << EOF
-NODE_ENV=production
-APP_ENV=${ENVIRONMENT}
-APP_NAME=${APP_NAME}
-NEXT_PUBLIC_SERVER_URL=${APP_URL}
-PAYLOAD_SECRET=${PAYLOAD_SECRET}
-EOF
+          printf '%s\n' \
+            "NODE_ENV=production" \
+            "APP_ENV=${ENVIRONMENT}" \
+            "APP_NAME=${APP_NAME}" \
+            "NEXT_PUBLIC_SERVER_URL=${APP_URL}" \
+            "PAYLOAD_SECRET=${PAYLOAD_SECRET}" \
+            > /tmp/app-env.txt
 
           .github/scripts/configure-caprover-app.sh \
             --app-name "${APP_NAME}" \

--- a/plugins/deploy/templates/deploy-standalone.yml
+++ b/plugins/deploy/templates/deploy-standalone.yml
@@ -127,10 +127,10 @@ jobs:
 
       - name: Write env file
         run: |
-          cat > /tmp/app.env <<'EOF'
-NODE_ENV=production
-PORT=__CONTAINER_PORT__
-EOF
+          printf '%s\n' \
+            'NODE_ENV=production' \
+            'PORT=__CONTAINER_PORT__' \
+            > /tmp/app.env
 
       - name: Configure CapRover app
         env:


### PR DESCRIPTION
## Summary

- Heredoc bodies at column 0 inside YAML `run: |` blocks break YAML parsing
- GitHub Actions rejects the workflow file entirely with no useful error
- Replaced `cat <<'EOF'` with `printf '%s\n'` in both standalone and monorepo templates

## Root cause

In YAML block scalars (`run: |`), content must be indented relative to the parent. Heredoc bodies written at column 0 (e.g., `NODE_ENV=production`) are parsed as YAML mapping keys, not as shell script content.

## Test plan

- [x] Both templates pass `npx yaml@2 valid`