### PR TITLE
fix: multi-arch build + curl error handling in deploy plugin

### DIFF
--- a/plugins/deploy/scripts/cleanup-dev-builds.sh
+++ b/plugins/deploy/scripts/cleanup-dev-builds.sh
@@ -160,12 +160,20 @@ echo "========================================="
 # Authenticate with dev CapRover
 echo ""
 echo "Authenticating with dev CapRover..."
+set +e
 LOGIN_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pw "$CAPROVER_PASSWORD" '{password: $pw}')")
+CURL_EXIT=$?
+set -e
 
-if ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
-  echo "Error: Dev CapRover returned non-JSON response (server may be down)"
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Error: curl failed (exit $CURL_EXIT). Dev CapRover may be unreachable (URL: $CAPROVER_URL)"
+  exit 1
+fi
+
+if [ -z "$LOGIN_RESPONSE" ] || ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: Dev CapRover returned non-JSON response (URL: $CAPROVER_URL)"
   exit 1
 fi
 
@@ -329,12 +337,20 @@ echo "========================================="
 # Authenticate with route CapRover
 echo ""
 echo "Authenticating with route CapRover..."
+set +e
 ROUTE_LOGIN_RESPONSE=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/login" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pw "$ROUTE_CAPROVER_PASSWORD" '{password: $pw}')")
+CURL_EXIT=$?
+set -e
 
-if ! echo "$ROUTE_LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
-  echo "Error: Route CapRover returned non-JSON response (server may be down)"
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Error: curl failed (exit $CURL_EXIT). Route CapRover may be unreachable (URL: $ROUTE_CAPROVER_URL)"
+  exit 1
+fi
+
+if [ -z "$ROUTE_LOGIN_RESPONSE" ] || ! echo "$ROUTE_LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: Route CapRover returned non-JSON response (URL: $ROUTE_CAPROVER_URL)"
   exit 1
 fi
 

--- a/plugins/deploy/scripts/configure-caprover-app.sh
+++ b/plugins/deploy/scripts/configure-caprover-app.sh
@@ -157,12 +157,20 @@ echo "========================================="
 # Authenticate with CapRover
 echo ""
 echo "Authenticating with CapRover..."
+set +e
 LOGIN_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pw "$CAPROVER_PASSWORD" '{password: $pw}')")
+CURL_EXIT=$?
+set -e
 
-if ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
-  echo "Error: CapRover returned non-JSON response (server may be down)"
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Error: curl failed (exit $CURL_EXIT). CapRover may be unreachable (URL: $CAPROVER_URL)"
+  exit 1
+fi
+
+if [ -z "$LOGIN_RESPONSE" ] || ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: CapRover returned non-JSON response (URL: $CAPROVER_URL)"
   exit 1
 fi
 

--- a/plugins/deploy/scripts/deploy-from-ghcr.sh
+++ b/plugins/deploy/scripts/deploy-from-ghcr.sh
@@ -119,12 +119,22 @@ echo "========================================="
 # Authenticate with CapRover
 echo ""
 echo "Authenticating with CapRover..."
-TOKEN=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
+set +e
+LOGIN_RESPONSE=$(curl -s -k -X POST "$CAPROVER_URL/api/v2/login" \
   -H "Content-Type: application/json" \
-  -d "{\"password\":\"$CAPROVER_PASSWORD\"}" | jq -r '.data.token')
+  -d "$(jq -n --arg pw "$CAPROVER_PASSWORD" '{password: $pw}')")
+CURL_EXIT=$?
+set -e
+
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Error: curl failed (exit $CURL_EXIT). CapRover may be unreachable (URL: $CAPROVER_URL)"
+  exit 1
+fi
+
+TOKEN=$(echo "$LOGIN_RESPONSE" | jq -r '.data.token' 2>/dev/null)
 
 if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-  echo "Error: Failed to authenticate"
+  echo "Error: Failed to authenticate with CapRover (URL: $CAPROVER_URL)"
   exit 1
 fi
 

--- a/plugins/deploy/scripts/setup-qwickway-route.sh
+++ b/plugins/deploy/scripts/setup-qwickway-route.sh
@@ -148,12 +148,20 @@ echo "========================================="
 # Step 1: Authenticate with route CapRover instance
 echo ""
 echo "Authenticating with route CapRover..."
+set +e
 LOGIN_RESPONSE=$(curl -s -k -X POST "$ROUTE_CAPROVER_URL/api/v2/login" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pw "$ROUTE_CAPROVER_PASSWORD" '{password: $pw}')")
+CURL_EXIT=$?
+set -e
 
-if ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
-  echo "Error: Route CapRover returned non-JSON response (server may be down)"
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Error: curl failed (exit $CURL_EXIT). Route CapRover may be unreachable (URL: $ROUTE_CAPROVER_URL)"
+  exit 1
+fi
+
+if [ -z "$LOGIN_RESPONSE" ] || ! echo "$LOGIN_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  echo "Error: Route CapRover returned non-JSON response (URL: $ROUTE_CAPROVER_URL)"
   exit 1
 fi
 

--- a/plugins/deploy/templates/deploy-standalone.yml
+++ b/plugins/deploy/templates/deploy-standalone.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.meta.outputs.image_ref }}
             ${{ env.REGISTRY }}/${{ env.OWNER }}/__APP_NAME__-${{ steps.env.outputs.environment }}:latest


### PR DESCRIPTION
## Summary
- Add `platforms: linux/amd64,linux/arm64` to standalone template
- Replace bare curl calls with `set +e`/`set -e` pattern in all 4 deploy scripts
- Curl failures now report exit code instead of letting `set -e` kill the script silently

## Test plan
- [ ] Verify scripts pass shellcheck
- [ ] Run /setup_workflow on a test repo and verify generated scripts have proper error handling