### PR TITLE
feat(sdlc): add autonomous_completion flag to item completion events

### DIFF
--- a/plugins/qwickapps-sop/references/sop-variables.md
+++ b/plugins/qwickapps-sop/references/sop-variables.md
@@ -87,6 +87,25 @@ Workflow action logging for traceability.
 |----------|---------|------------|-------------------|
 | `AUDIT_LOG` | Log a workflow action | agent, event, payload | Skip (no audit logging) |
 
+#### autonomous_completion Convention
+
+When an agent (not a human) marks a PM item as complete, the `AUDIT_LOG` call **must** include `autonomous_completion: true` in the payload. This distinguishes agent-driven completions from human-driven ones in the audit trail and enables downstream metrics on agent autonomy.
+
+Required call pattern whenever `PM_UPDATE_ITEM` is called with `status: done`:
+
+```
+AUDIT_LOG:
+  agent: <agent-identifier>
+  event: item_completed
+  item_id: <PM item UUID>
+  payload:
+    autonomous_completion: true
+```
+
+For human-initiated completions (e.g., a user manually closing an item), set `autonomous_completion: false` or omit the field entirely — the absence of the flag is treated as a human action by convention.
+
+**Never omit the `AUDIT_LOG` call when an agent sets `status: done`.** If `AUDIT_LOG` is unavailable (no SOP configured), log a local note that the item was autonomously completed.
+
 ### Worktree / Branch Isolation (WORKTREE_*)
 
 Configuration for isolated workspaces during development.

--- a/plugins/sdlc/skills/delegating-tasks/SKILL.md
+++ b/plugins/sdlc/skills/delegating-tasks/SKILL.md
@@ -104,7 +104,14 @@ If code quality reviewer returns issues:
 
 **Step 8: Mark task complete**
 
-Update the TodoWrite entry for this task to complete. Move to the next task.
+Update the TodoWrite entry for this task to complete.
+
+If the task has an associated PM item, call `AUDIT_LOG` immediately after marking complete:
+- `event`: `item_completed`
+- `item_id`: the PM item UUID
+- `payload`: `{ "autonomous_completion": true }`
+
+Move to the next task.
 
 ### After All Tasks
 

--- a/plugins/sdlc/skills/executing-plans/SKILL.md
+++ b/plugins/sdlc/skills/executing-plans/SKILL.md
@@ -36,6 +36,10 @@ The default batch size is 3 tasks. For each task in the batch:
 2. Execute each step in the task exactly as written in the plan
 3. Run verifications as specified — do not skip them
 4. Mark the task as completed using TaskUpdate
+5. If the task has an associated PM item, call `AUDIT_LOG` immediately after marking complete:
+   - `event`: `item_completed`
+   - `item_id`: the PM item UUID
+   - `payload`: `{ "autonomous_completion": true }`
 
 Execute steps literally. The plan was written to be followed as written. Do not substitute alternative implementations, skip steps that seem redundant, or combine steps to save time.
 


### PR DESCRIPTION
## Summary
- Establishes a mandatory convention: when an agent autonomously completes a PM item (`PM_UPDATE_ITEM` with `status: done`), it must immediately follow with an `AUDIT_LOG` call carrying `payload: { autonomous_completion: true }`
- Documents the full convention in `sop-variables.md` including call pattern, fallback behavior, and the human-vs-agent distinction
- Adds step 5 to `executing-plans` (per-task batch loop) and updates step 8 in `delegating-tasks` (per-task delegated loop)

## Test plan
- [ ] `executing-plans` step 2 now lists 5 sub-steps; step 5 references AUDIT_LOG with `item_completed` + `autonomous_completion: true`
- [ ] `delegating-tasks` step 8 now instructs AUDIT_LOG call before moving to next task
- [ ] `sop-variables.md` `autonomous_completion Convention` section present with required call pattern block
- [ ] Diff is purely additive — no existing behavior removed

Closes #I1

🤖 Generated with [Claude Code](https://claude.com/claude-code)