### PR TITLE
feat(sdlc): pin per-agent model

### DIFF
--- a/plugins/sdlc/agents/architect.md
+++ b/plugins/sdlc/agents/architect.md
@@ -1,6 +1,7 @@
 ---
 name: architect
 description: Senior software architect for designing implementation approaches. Use when /feature or /refactor requires architectural decisions, pattern selection, or system design. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.
+model: sonnet
 capabilities:
   - Multi-tier architecture design
   - API specification

--- a/plugins/sdlc/agents/code-reviewer.md
+++ b/plugins/sdlc/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: code-reviewer
 description: Senior code reviewer specialized in quality analysis and improvement suggestions. Use when dispatching code review via Task tool after completing work. Focuses on correctness, clarity, performance, security, and adherence to established patterns.
+model: sonnet
 capabilities:
   - Security vulnerability detection (OWASP top 10)
   - Code quality assessment (DRY, YAGNI, naming, readability)

--- a/plugins/sdlc/agents/coder.md
+++ b/plugins/sdlc/agents/coder.md
@@ -1,6 +1,7 @@
 ---
 name: coder
 description: Senior software engineer specialized in implementation. Use when /feature, /bug, or /chore needs high-quality, production-ready code. Follows TDD, writes clean code, and maintains consistency with existing codebase.
+model: sonnet
 capabilities:
   - Clean code implementation following existing patterns
   - TDD (RED-GREEN-REFACTOR)

--- a/plugins/sdlc/agents/devops.md
+++ b/plugins/sdlc/agents/devops.md
@@ -1,6 +1,7 @@
 ---
 name: devops
 description: DevOps engineer for deployment and infrastructure. Use when /release needs deployment automation, CI/CD pipeline setup, or infrastructure management.
+model: sonnet
 capabilities:
   - CI/CD pipeline configuration
   - Docker and container management

--- a/plugins/sdlc/agents/engineering-manager.md
+++ b/plugins/sdlc/agents/engineering-manager.md
@@ -1,6 +1,7 @@
 ---
 name: engineering-manager
 description: Engineering manager for release coordination and team planning. Use when /release needs cross-team coordination, priority management, or release planning.
+model: sonnet
 capabilities:
   - Release coordination
   - Priority management

--- a/plugins/sdlc/agents/product-manager.md
+++ b/plugins/sdlc/agents/product-manager.md
@@ -1,6 +1,7 @@
 ---
 name: product-manager
 description: Product requirements manager for gathering and refining requirements. Use when the /feature command needs requirements discovery, user story writing, acceptance criteria definition, or feature prioritization.
+model: sonnet
 capabilities:
   - Requirements gathering through interactive conversation
   - User story and acceptance criteria writing

--- a/plugins/sdlc/agents/quality-engineer.md
+++ b/plugins/sdlc/agents/quality-engineer.md
@@ -1,6 +1,7 @@
 ---
 name: quality-engineer
 description: QA engineer specialized in testing strategy and quality assurance. Use when /feature or /bug needs comprehensive testing coverage, quality gates, or testing strategies across all testing levels.
+model: sonnet
 capabilities:
   - Test strategy design (unit, integration, E2E)
   - Edge case identification

--- a/plugins/sdlc/agents/tech-writer.md
+++ b/plugins/sdlc/agents/tech-writer.md
@@ -1,6 +1,7 @@
 ---
 name: tech-writer
 description: Technical writing expert for documentation. Use when /docs or /feature needs clear technical documentation, guides, tutorials, API references, or onboarding materials.
+model: haiku
 capabilities:
   - Developer-focused documentation
   - API reference writing


### PR DESCRIPTION
## Why

Spawned sdlc agents inherit the parent's model. Today four agents stalled mid-generation under Opus 4.7's 1M-context variant — `API Error: Stream idle timeout - partial response received`. Pinning each agent to a specific model bypasses inheritance and uses a more reliable streaming variant.

## What

Adds `model:` frontmatter to each of the 8 sdlc agents:
- `sonnet` for architect, coder, code-reviewer, devops, engineering-manager, product-manager, quality-engineer
- `haiku` for tech-writer (docs are mostly transcription; Haiku 4.5 is cheaper and fast enough)

## Note

This is a stopgap. The team is migrating to a litellm proxy that will handle model routing centrally; this change can be reverted (or simplified to defer to the proxy) when that lands.