### PR TITLE
fix(hooks): double-quote ${CLAUDE_PLUGIN_ROOT} so shell expansion works

### DIFF
--- a/plugins/qwickapps-sop/hooks/hooks.json
+++ b/plugins/qwickapps-sop/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh'",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
             "async": false
           }
         ]

--- a/plugins/sdlc/hooks/hooks.json
+++ b/plugins/sdlc/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh'",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
             "async": false
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-check.sh'",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-check.sh\"",
             "timeout": 10
           }
         ]

--- a/plugins/secrets/hooks/hooks.json
+++ b/plugins/secrets/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh'",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
             "async": false
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash '${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-guard.sh'",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-guard.sh\"",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary
- Plugin hook commands wrapped `${CLAUDE_PLUGIN_ROOT}` in **single quotes**, so the shell never expanded it. SessionStart and PreToolUse hooks failed at startup with:
  ```
  bash: ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh: No such file or directory
  ```
- Switched to **double quotes** in the three affected plugins (`sdlc`, `qwickapps-sop`, `secrets`). Still safe for paths with spaces, but allows variable expansion.

## Affected files
- `plugins/sdlc/hooks/hooks.json` (SessionStart + PreToolUse)
- `plugins/qwickapps-sop/hooks/hooks.json` (SessionStart)
- `plugins/secrets/hooks/hooks.json` (SessionStart + PreToolUse)

Other plugin hooks already use unquoted or correct forms (`ux-design` uses bare `${CLAUDE_PLUGIN_ROOT}`).

## Test plan
- [ ] Bump the affected plugin versions in their `.claude-plugin/plugin.json` (if marketplace versioning requires it)
- [ ] Reload plugins (`/reload-plugins`) in a fresh Claude Code session
- [ ] Confirm no `SessionStart:startup hook error` at startup
- [ ] Verify `<sop-config>` block from qwickapps-sop session-start hook is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)