### PR TITLE
feat(deploy): wildcard SSL setup + use wildcard certs for base domains

### DIFF
--- a/plugins/deploy/.claude-plugin/plugin.json
+++ b/plugins/deploy/.claude-plugin/plugin.json
@@ -13,6 +13,10 @@
     "github-actions",
     "ghcr",
     "docker",
-    "ci-cd"
+    "ci-cd",
+    "ssl",
+    "wildcard",
+    "letsencrypt",
+    "cloudflare"
   ]
 }

--- a/plugins/deploy/README.md
+++ b/plugins/deploy/README.md
@@ -58,6 +58,7 @@ All scripts are self-contained bash scripts with `--flag` interfaces. They use `
 | `setup-ghcr-package.sh` | Copied from qwickapps | Configures GHCR package permissions |
 | `setup-qwickway-route.sh` | New | Provisions QwickWay gateway on route CapRover |
 | `cleanup-dev-builds.sh` | New | Keeps last N dev builds, deletes older ones |
+| `setup-wildcard-ssl.sh` | New | Sets up wildcard SSL cert on a CapRover server |
 
 ## Workflow Templates
 
@@ -89,6 +90,7 @@ For qwickapps monorepo products. Uses `self-hosted` runner with `zsh` shell.
 
 - **provisioning**: CapRover + QwickWay provisioning guidance
 - **troubleshooting**: Deployment debugging (common errors, log analysis, rollback)
+- **wildcard-ssl**: Let's Encrypt wildcard SSL setup and management for CapRover servers
 
 ## Plugin Structure
 
@@ -99,6 +101,7 @@ plugins/deploy/
   skills/
     provisioning/SKILL.md
     troubleshooting/SKILL.md
+    wildcard-ssl/SKILL.md
   scripts/
     configure-caprover-app.sh
     deploy-from-ghcr.sh
@@ -106,6 +109,7 @@ plugins/deploy/
     setup-ghcr-package.sh
     setup-qwickway-route.sh
     cleanup-dev-builds.sh
+    setup-wildcard-ssl.sh
   templates/
     deploy-standalone.yml
     deploy-monorepo-product.yml

--- a/plugins/deploy/scripts/configure-caprover-app.sh
+++ b/plugins/deploy/scripts/configure-caprover-app.sh
@@ -222,30 +222,13 @@ else
   fi
 fi
 
-# Enable HTTPS on the base CapRover domain (required before forceSsl can be set)
+# Base domain SSL: Wildcard certs are installed on all CapRover servers.
+# Instead of calling enablebasedomainssl (which requests individual Let's Encrypt certs
+# and risks rate limits), we set hasDefaultSubDomainSsl=true directly in the app definition.
+# The wildcard-ssl-sync cron job ensures the cert symlink exists within 5 minutes.
 if [ "$ENABLE_SSL" = "true" ]; then
   echo ""
-  echo "Enabling HTTPS on base domain..."
-  SSL_RESPONSE=$(caprover_api_call "Enable base domain SSL" \
-    curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/enablebasedomainssl" \
-    -H "Content-Type: application/json" \
-    -H "x-captain-auth: $TOKEN" \
-    -d "$(jq -n --arg app "$APP_NAME" '{appName: $app}')")
-
-  SSL_STATUS=$(echo "$SSL_RESPONSE" | jq -r '.status')
-  if [ "$SSL_STATUS" = "100" ]; then
-    echo "  HTTPS enabled on base domain"
-  else
-    SSL_DESC=$(echo "$SSL_RESPONSE" | jq -r '.description // "Unknown error"')
-    # "already enabled" is not an error
-    if echo "$SSL_DESC" | grep -iq "already"; then
-      echo "  HTTPS already enabled on base domain"
-    else
-      echo "  Warning: Could not enable HTTPS: $SSL_DESC"
-      echo "  Continuing without forceSsl..."
-      FORCE_SSL="false"
-    fi
-  fi
+  echo "Base domain SSL: using wildcard cert (no individual cert request needed)"
 fi
 
 # Fetch current app definition (read-then-write: preserves all existing fields)
@@ -271,7 +254,8 @@ MERGED=$(echo "$CURRENT_DEF" | jq \
   --argjson count "$INSTANCE_COUNT" \
   --argjson port "$CONTAINER_PORT" \
   --argjson ssl "$FORCE_SSL" \
-  '.instanceCount = $count | .containerHttpPort = $port | .forceSsl = $ssl | .websocketSupport = true | .appDeployTokenConfig = (.appDeployTokenConfig // {} | .enabled = true)')
+  --argjson basessl "$([ "$ENABLE_SSL" = "true" ] && echo true || echo false)" \
+  '.instanceCount = $count | .containerHttpPort = $port | .forceSsl = $ssl | .hasDefaultSubDomainSsl = $basessl | .websocketSupport = true | .appDeployTokenConfig = (.appDeployTokenConfig // {} | .enabled = true)')
 
 # Merge environment variables if env file provided
 if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then

--- a/plugins/deploy/scripts/setup-wildcard-ssl.sh
+++ b/plugins/deploy/scripts/setup-wildcard-ssl.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# setup-wildcard-ssl.sh
+#
+# Sets up a Let's Encrypt wildcard certificate on a CapRover server using
+# DNS-01 challenge via Cloudflare. Creates sync script, cron job, and
+# renewal hook so all CapRover apps use the wildcard cert automatically.
+#
+# Usage:
+#   bash setup-wildcard-ssl.sh \
+#     --server oci-dev \
+#     --domain dev.qwickforge.com \
+#     --cloudflare-token <CLOUDFLARE_EDIT_DNS_TOKEN>
+#
+# Prerequisites:
+#   - SSH access to the server (via ~/.ssh/config alias)
+#   - sudo on the target server
+#   - Server must be running CapRover with nginx
+
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Parse arguments
+# ──────────────────────────────────────────────────────────────────────────────
+
+SERVER=""
+DOMAIN=""
+CF_TOKEN=""
+EMAIL="admin@qwickapps.com"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server)
+      SERVER="$2"
+      shift 2
+      ;;
+    --domain)
+      DOMAIN="$2"
+      shift 2
+      ;;
+    --cloudflare-token)
+      CF_TOKEN="$2"
+      shift 2
+      ;;
+    --email)
+      EMAIL="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$SERVER" ] || [ -z "$DOMAIN" ] || [ -z "$CF_TOKEN" ]; then
+  echo "Usage: bash setup-wildcard-ssl.sh --server <ssh-host> --domain <caprover-domain> --cloudflare-token <token>"
+  exit 1
+fi
+
+WILDCARD_NAME="wildcard.$DOMAIN"
+
+echo "=========================================="
+echo "Wildcard SSL Setup"
+echo "  Server:  $SERVER"
+echo "  Domain:  *.$DOMAIN"
+echo "  Email:   $EMAIL"
+echo "=========================================="
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 1: Install certbot and Cloudflare DNS plugin
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 1: Installing certbot and Cloudflare DNS plugin..."
+ssh "$SERVER" "
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq certbot python3-certbot-dns-cloudflare
+" 2>&1 | tail -3
+echo "  Done"
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 2: Create Cloudflare credentials file
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 2: Creating Cloudflare credentials..."
+ssh "$SERVER" "
+  sudo mkdir -p /etc/letsencrypt
+  echo 'dns_cloudflare_api_token = $CF_TOKEN' | sudo tee /etc/letsencrypt/cloudflare.ini > /dev/null
+  sudo chmod 600 /etc/letsencrypt/cloudflare.ini
+"
+echo "  Created /etc/letsencrypt/cloudflare.ini"
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 3: Obtain wildcard certificate
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 3: Obtaining wildcard certificate for *.$DOMAIN..."
+ssh "$SERVER" "
+  sudo certbot certonly \
+    --dns-cloudflare \
+    --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini \
+    --dns-cloudflare-propagation-seconds 30 \
+    -d '*.$DOMAIN' \
+    -d '$DOMAIN' \
+    --email '$EMAIL' \
+    --agree-tos \
+    --non-interactive \
+    2>&1
+"
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 4: Copy wildcard cert to CapRover's cert directory
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 4: Copying wildcard cert to CapRover cert store..."
+ssh "$SERVER" "
+  CERT_DIR=/captain/data/letencrypt/etc/live
+  WILDCARD_DIR=\$CERT_DIR/$WILDCARD_NAME
+
+  sudo mkdir -p \$WILDCARD_DIR
+  sudo cp /etc/letsencrypt/live/$DOMAIN/fullchain.pem \$WILDCARD_DIR/
+  sudo cp /etc/letsencrypt/live/$DOMAIN/privkey.pem \$WILDCARD_DIR/
+  sudo cp /etc/letsencrypt/live/$DOMAIN/chain.pem \$WILDCARD_DIR/
+  sudo cp /etc/letsencrypt/live/$DOMAIN/cert.pem \$WILDCARD_DIR/
+"
+echo "  Copied to /captain/data/letencrypt/etc/live/$WILDCARD_NAME/"
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 5: Replace all existing app cert directories with symlinks
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 5: Replacing individual cert directories with wildcard symlinks..."
+REPLACED=$(ssh "$SERVER" "
+  CERT_DIR=/captain/data/letencrypt/etc/live
+  count=0
+  for entry in \$(sudo ls \$CERT_DIR | grep -v README | grep -v '$WILDCARD_NAME'); do
+    if [ ! -L \"\$CERT_DIR/\$entry\" ]; then
+      sudo rm -rf \"\$CERT_DIR/\$entry\"
+      sudo ln -s $WILDCARD_NAME \"\$CERT_DIR/\$entry\"
+      count=\$((count + 1))
+    fi
+  done
+  echo \$count
+")
+echo "  Replaced $REPLACED cert directories with symlinks"
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 6: Create sync script and cron job
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 6: Creating sync script and cron job..."
+ssh "$SERVER" "
+  sudo tee /captain/data/wildcard-ssl-sync.sh > /dev/null << 'SYNCSCRIPT'
+#!/bin/bash
+CERT_DIR=/captain/data/letencrypt/etc/live
+WILDCARD=$WILDCARD_NAME
+
+for entry in \$CERT_DIR/*.$DOMAIN; do
+  name=\$(basename \"\$entry\")
+  [ \"\$name\" = \"\$WILDCARD\" ] && continue
+  if [ ! -L \"\$entry\" ]; then
+    rm -rf \"\$entry\"
+    ln -s \$WILDCARD \"\$entry\"
+    echo \"Replaced \$name with wildcard symlink\"
+  fi
+done
+
+if [ -n \"\$1\" ]; then
+  target=\"\$CERT_DIR/\$1.$DOMAIN\"
+  if [ ! -e \"\$target\" ]; then
+    ln -s \$WILDCARD \"\$target\"
+    echo \"Created wildcard symlink for \$1\"
+  fi
+fi
+SYNCSCRIPT
+  sudo chmod +x /captain/data/wildcard-ssl-sync.sh
+
+  # Add cron job (replace existing if present)
+  (sudo crontab -l 2>/dev/null | grep -v wildcard-ssl-sync; echo '*/5 * * * * /captain/data/wildcard-ssl-sync.sh >> /var/log/wildcard-ssl-sync.log 2>&1') | sudo crontab -
+"
+echo "  Created /captain/data/wildcard-ssl-sync.sh"
+echo "  Added cron job (every 5 minutes)"
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 7: Create renewal hook
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 7: Creating renewal hook..."
+ssh "$SERVER" "
+  sudo mkdir -p /etc/letsencrypt/renewal-hooks/deploy
+  sudo tee /etc/letsencrypt/renewal-hooks/deploy/caprover-wildcard.sh > /dev/null << 'RENEWHOOK'
+#!/bin/bash
+CAPROVER_CERT=/captain/data/letencrypt/etc/live/$WILDCARD_NAME
+LE_CERT=/etc/letsencrypt/live/$DOMAIN
+cp \$LE_CERT/fullchain.pem \$CAPROVER_CERT/
+cp \$LE_CERT/privkey.pem \$CAPROVER_CERT/
+cp \$LE_CERT/chain.pem \$CAPROVER_CERT/
+cp \$LE_CERT/cert.pem \$CAPROVER_CERT/
+NGINX_CONTAINER=\$(docker ps --format '{{.Names}}' | grep captain-nginx)
+docker exec \$NGINX_CONTAINER nginx -s reload 2>/dev/null
+echo \"\$(date): Wildcard cert renewed and nginx reloaded\" >> /var/log/wildcard-ssl-sync.log
+RENEWHOOK
+  sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/caprover-wildcard.sh
+"
+echo "  Created /etc/letsencrypt/renewal-hooks/deploy/caprover-wildcard.sh"
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 8: Test nginx and reload
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 8: Testing nginx configuration..."
+NGINX_TEST=$(ssh "$SERVER" "
+  NGINX_CONTAINER=\$(docker ps --format '{{.Names}}' | grep captain-nginx)
+  docker exec \$NGINX_CONTAINER nginx -t 2>&1
+  echo '---'
+  docker exec \$NGINX_CONTAINER nginx -s reload 2>&1
+")
+
+if echo "$NGINX_TEST" | grep -q "test is successful"; then
+  echo "  Nginx config valid, reloaded"
+else
+  echo "  WARNING: Nginx test failed:"
+  echo "$NGINX_TEST"
+  exit 1
+fi
+echo ""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Step 9: Verify
+# ──────────────────────────────────────────────────────────────────────────────
+
+echo "Step 9: Verifying wildcard cert is served..."
+CERT_SUBJECT=$(ssh "$SERVER" "
+  echo | openssl s_client -connect 127.0.0.1:443 -servername captain.$DOMAIN 2>/dev/null | openssl x509 -noout -subject 2>/dev/null
+")
+echo "  $CERT_SUBJECT"
+
+if echo "$CERT_SUBJECT" | grep -q "\*\.$DOMAIN"; then
+  echo ""
+  echo "=========================================="
+  echo "  Wildcard SSL setup complete!"
+  echo "  *.$DOMAIN is now covered."
+  echo "=========================================="
+else
+  echo ""
+  echo "  WARNING: Wildcard cert not yet served. May need a moment for nginx to pick up changes."
+fi

--- a/plugins/deploy/skills/provisioning/SKILL.md
+++ b/plugins/deploy/skills/provisioning/SKILL.md
@@ -127,7 +127,9 @@ Set `containerHttpPort` to match the port your application listens on. Mismatche
 
 ### SSL and Domain Configuration
 
-After creating an app, enable the custom domain and force SSL:
+**Base domain SSL (e.g., myapp.app.qwickforge.com):** All CapRover servers have wildcard certs installed. Do NOT call the `enablebasedomainssl` API — it requests individual certs and risks Let's Encrypt rate limits. Instead, set `hasDefaultSubDomainSsl: true` directly in the app definition update. The wildcard cert covers all `*.<server-domain>` subdomains automatically. See the `wildcard-ssl` skill for details.
+
+**Custom domain SSL (e.g., example.com):** Custom domains on QwickWay gateways still need individual certs:
 
 ```bash
 # Add custom domain
@@ -136,7 +138,7 @@ curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/customdomain" 
   -H "x-captain-auth: $TOKEN" \
   -d '{"appName":"<name>","customDomain":"example.com"}'
 
-# Enable SSL (Let's Encrypt)
+# Enable SSL (Let's Encrypt) - only for custom domains, not base CapRover domains
 curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/enablecustomdomainssl" \
   -H "Content-Type: application/json" \
   -H "x-captain-auth: $TOKEN" \
@@ -146,7 +148,7 @@ curl -s -k -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/enablecustomdo
 # Set forceSsl: true in the app definition update
 ```
 
-SSL provisioning requires DNS to be pointed at the server before calling `enablecustomdomainssl`. If DNS has not propagated, the Let's Encrypt challenge will fail.
+Custom domain SSL requires DNS to be pointed at the server before calling `enablecustomdomainssl`. If DNS has not propagated, the Let's Encrypt challenge will fail.
 
 ---
 

--- a/plugins/deploy/skills/wildcard-ssl/SKILL.md
+++ b/plugins/deploy/skills/wildcard-ssl/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: wildcard-ssl
+description: >
+  This skill should be used when setting up or troubleshooting wildcard SSL certificates
+  on CapRover servers, when adding a new CapRover server to the infrastructure, when
+  debugging SSL certificate issues or Let's Encrypt rate limits, or when understanding
+  how SSL works across the deployment infrastructure. Trigger phrases: "wildcard SSL",
+  "SSL certificate", "Let's Encrypt", "rate limit", "certificate error", "HTTPS setup",
+  "set up SSL on CapRover", "cert expired", "SSL renewal".
+---
+
+# Wildcard SSL for CapRover
+
+All three CapRover servers use Let's Encrypt wildcard certificates via DNS-01 challenge with Cloudflare. This eliminates per-app certificate requests and avoids Let's Encrypt rate limits.
+
+---
+
+## Architecture
+
+Each CapRover server has a single wildcard certificate that covers all apps on its domain:
+
+| Server | Wildcard Cert | Covers |
+|--------|--------------|--------|
+| oci-dev | `*.dev.qwickforge.com` | All dev apps |
+| oci-main | `*.app.qwickforge.com` | All prod and uat apps |
+| oci-gateway | `*.route.qwickforge.com` | All QwickWay gateway apps |
+
+CapRover expects individual cert directories per app at `/captain/data/letencrypt/etc/live/<app>.<domain>/`. The wildcard system creates relative symlinks from each app's cert directory to the wildcard cert directory:
+
+```
+/captain/data/letencrypt/etc/live/
+  wildcard.dev.qwickforge.com/     <-- real directory with wildcard cert files
+  faabzi.dev.qwickforge.com        -> wildcard.dev.qwickforge.com  (symlink)
+  work-macha.dev.qwickforge.com    -> wildcard.dev.qwickforge.com  (symlink)
+  captain.dev.qwickforge.com       -> wildcard.dev.qwickforge.com  (symlink)
+```
+
+**Important:** Symlinks must be **relative** (just the directory name, not absolute paths) because nginx runs inside a Docker container with different mount paths than the host.
+
+---
+
+## Components on Each Server
+
+### 1. Wildcard Certificate
+
+Obtained via certbot with the Cloudflare DNS plugin:
+
+```bash
+sudo certbot certonly \
+  --dns-cloudflare \
+  --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini \
+  --dns-cloudflare-propagation-seconds 30 \
+  -d '*.DOMAIN' \
+  -d 'DOMAIN' \
+  --email admin@qwickapps.com \
+  --agree-tos \
+  --non-interactive
+```
+
+The cert is stored at `/etc/letsencrypt/live/DOMAIN/` and copied to CapRover's cert directory at `/captain/data/letencrypt/etc/live/wildcard.DOMAIN/`.
+
+### 2. Cloudflare Credentials
+
+Stored at `/etc/letsencrypt/cloudflare.ini` with mode `600`:
+
+```ini
+dns_cloudflare_api_token = <CLOUDFLARE_EDIT_DNS_TOKEN>
+```
+
+The token is the `CLOUDFLARE_EDIT_DNS_TOKEN` from `environments.yml` (infrastructure.cloudflare.secrets section).
+
+### 3. Sync Script
+
+Located at `/captain/data/wildcard-ssl-sync.sh`. Runs every 5 minutes via cron. Replaces any real cert directory (created by CapRover's individual cert requests) with a symlink to the wildcard cert.
+
+The script also accepts an app name argument to pre-create a symlink:
+
+```bash
+/captain/data/wildcard-ssl-sync.sh myapp
+```
+
+### 4. Renewal Hook
+
+Located at `/etc/letsencrypt/renewal-hooks/deploy/caprover-wildcard.sh`. When certbot auto-renews the wildcard cert, this hook copies the new cert to CapRover's cert directory and reloads nginx.
+
+### 5. Auto-Renewal
+
+Certbot's systemd timer (`certbot.timer`) runs twice daily and handles renewal automatically. The renewal hook ensures CapRover picks up the new cert.
+
+---
+
+## How New Apps Get SSL
+
+When a new CapRover app is created and `hasDefaultSubDomainSsl` is set to `true` in its configuration:
+
+1. The deployment script sets `hasDefaultSubDomainSsl: true` in the app definition (no API call to `enablebasedomainssl` needed).
+2. CapRover generates nginx config pointing to `/letencrypt/etc/live/<app>.DOMAIN/fullchain.pem`.
+3. Within 5 minutes, the cron job creates a symlink from `<app>.DOMAIN` to `wildcard.DOMAIN`.
+4. Nginx serves the wildcard cert for the new app.
+
+If immediate SSL is needed (before the 5-minute cron), run the sync script manually via SSH:
+
+```bash
+ssh <server> "sudo /captain/data/wildcard-ssl-sync.sh <app-name>"
+```
+
+---
+
+## Custom Domain SSL
+
+Wildcard certs only cover `*.<server-domain>` subdomains. Custom domains (e.g., `faabzi.com`, `dev.faabzi.com`) on the QwickWay gateway still use individual Let's Encrypt certs via the `enablecustomdomainssl` API call. This is handled by the `setup-qwickway-route.sh` script and is unaffected by the wildcard setup.
+
+---
+
+## Setting Up Wildcard SSL on a New Server
+
+Use the `setup-wildcard-ssl.sh` script from `${CLAUDE_PLUGIN_ROOT}/scripts/`:
+
+```bash
+bash setup-wildcard-ssl.sh \
+  --server <ssh-host> \
+  --domain <caprover-root-domain> \
+  --cloudflare-token <token>
+```
+
+The script:
+1. Installs certbot and the Cloudflare DNS plugin
+2. Creates the Cloudflare credentials file
+3. Obtains the wildcard certificate
+4. Copies it to CapRover's cert directory
+5. Replaces all existing app cert directories with symlinks
+6. Creates the sync script and cron job
+7. Creates the renewal hook
+8. Tests and reloads nginx
+
+---
+
+## Troubleshooting
+
+### Certificate shows old CN (not wildcard)
+
+The symlink may not exist yet. Check and fix:
+
+```bash
+ssh <server> "sudo ls -la /captain/data/letencrypt/etc/live/<app>.<domain>"
+# If it's a real directory (not symlink), run:
+ssh <server> "sudo /captain/data/wildcard-ssl-sync.sh"
+```
+
+### Nginx fails to start after symlink creation
+
+Symlinks must be relative. Verify:
+
+```bash
+# Correct (relative):
+faabzi.dev.qwickforge.com -> wildcard.dev.qwickforge.com
+
+# Wrong (absolute - will fail in nginx container):
+faabzi.dev.qwickforge.com -> /captain/data/letencrypt/etc/live/wildcard.dev.qwickforge.com
+```
+
+Fix absolute symlinks:
+
+```bash
+ssh <server> "
+  CERT_DIR=/captain/data/letencrypt/etc/live
+  for link in \$(sudo find \$CERT_DIR -maxdepth 1 -type l); do
+    target=\$(readlink \$link)
+    if [[ \$target == /* ]]; then
+      name=\$(basename \$link)
+      sudo rm \$link
+      sudo ln -s wildcard.<domain> \$CERT_DIR/\$name
+    fi
+  done
+"
+```
+
+### Wildcard cert expired
+
+Check renewal status:
+
+```bash
+ssh <server> "sudo certbot certificates"
+ssh <server> "sudo systemctl status certbot.timer"
+```
+
+Force renewal:
+
+```bash
+ssh <server> "sudo certbot renew --force-renewal"
+```
+
+The renewal hook automatically copies the new cert to CapRover and reloads nginx.
+
+### Rate limit errors
+
+With the wildcard cert, per-app rate limits are no longer an issue. If you see rate limit errors, an old workflow or script may still be calling `enablebasedomainssl`. Update the workflow to use `--enable-ssl false` and set `hasDefaultSubDomainSsl: true` directly in the app definition.
+
+---
+
+## Server Reference
+
+| Server | SSH Host | Domain | Cert Path |
+|--------|----------|--------|-----------|
+| oci-dev | `oci-dev` | `dev.qwickforge.com` | `/etc/letsencrypt/live/dev.qwickforge.com/` |
+| oci-main | `oci-main` | `app.qwickforge.com` | `/etc/letsencrypt/live/app.qwickforge.com/` |
+| oci-gateway | `oci-gateway` | `route.qwickforge.com` | `/etc/letsencrypt/live/route.qwickforge.com/` |
+
+Cloudflare credentials: `/etc/letsencrypt/cloudflare.ini` (same token on all servers)
+
+Sync script: `/captain/data/wildcard-ssl-sync.sh` (server-specific wildcard name)
+
+Renewal hook: `/etc/letsencrypt/renewal-hooks/deploy/caprover-wildcard.sh`
+
+Cron: `*/5 * * * * /captain/data/wildcard-ssl-sync.sh`


### PR DESCRIPTION
## Summary
- New `setup-wildcard-ssl.sh` script provisions a Let's Encrypt wildcard cert per CapRover server via DNS-01 (Cloudflare). Installs a sync script + cron job + renewal hook that symlinks the wildcard cert into each app's expected `/captain/data/letencrypt/etc/live/<app>.<domain>/` directory.
- New `wildcard-ssl` skill documents the architecture, troubleshooting, and adding a new server.
- `configure-caprover-app.sh` no longer calls the `enablebasedomainssl` API (which requests individual Let's Encrypt certs and burns rate-limit quota). Instead it sets `hasDefaultSubDomainSsl: true` directly in the app definition — the wildcard cert covers it.
- Custom-domain SSL (non-CapRover-subdomain) still uses `enablecustomdomainssl` as before.

## Affected files
- New: `plugins/deploy/scripts/setup-wildcard-ssl.sh`, `plugins/deploy/skills/wildcard-ssl/SKILL.md`
- Modified: `plugins/deploy/scripts/configure-caprover-app.sh`, `plugins/deploy/skills/provisioning/SKILL.md`, `plugins/deploy/README.md`, `plugins/deploy/.claude-plugin/plugin.json`

## Test plan
- [ ] Run `setup-wildcard-ssl.sh` end-to-end against a fresh CapRover server (oci-* host with Cloudflare-managed domain)
- [ ] Confirm wildcard cert appears at `/captain/data/letencrypt/wildcard/` and symlinks exist under `etc/live/`
- [ ] Deploy a new app via `configure-caprover-app.sh --enable-ssl` and confirm HTTPS works on the base domain without an individual cert request
- [ ] Confirm cron sync job is scheduled and renewal hook is in place
- [ ] Custom-domain SSL flow still works for apps on QwickWay-fronted domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)