### PR TITLE
fix(hooks): self-resolve plugin root without CLAUDE_PLUGIN_ROOT env var

### DIFF
--- a/plugins/qwickapps-sop/hooks/hooks.json
+++ b/plugins/qwickapps-sop/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/qwickapps-sop/*/hooks/session-start.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'",
             "async": false
           }
         ]

--- a/plugins/sdlc/hooks/hooks.json
+++ b/plugins/sdlc/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sdlc/*/hooks/session-start.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'",
             "async": false
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-check.sh\"",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sdlc/*/hooks/pre-commit-check.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'",
             "timeout": 10
           }
         ]

--- a/plugins/secrets/hooks/hooks.json
+++ b/plugins/secrets/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/secrets/*/hooks/session-start.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'",
             "async": false
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-commit-guard.sh\"",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/secrets/*/hooks/pre-commit-guard.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'",
             "timeout": 10
           }
         ]

--- a/plugins/ux-design/hooks/hooks.json
+++ b/plugins/ux-design/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-framework-usage.sh"
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/ux-design/*/hooks/enforce-framework-usage.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-framework-usage.sh"
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/ux-design/*/hooks/enforce-framework-usage.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'"
           }
         ]
       },
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-framework-usage.sh"
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/ux-design/*/hooks/enforce-framework-usage.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Claude Code's plugin runtime does not inject `CLAUDE_PLUGIN_ROOT` into hook command environments, so every `bash "${CLAUDE_PLUGIN_ROOT}/hooks/<script>.sh"` silently resolves to `bash "/hooks/<script>.sh"` and fails. This was patched locally by hardcoding absolute paths, but the source needed a lasting fix.

This PR replaces all four `hooks.json` files with a glob-based self-discovery pattern:

```bash
bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/<plugin-name>/*/hooks/<script>.sh 2>/dev/null | sort -V | tail -1); [ -n "$f" ] && bash "$f" || exit 0'
```

- The glob `*/` matches any installed version; `sort -V | tail -1` picks the latest semver.
- `exit 0` fallback makes a missing cache entry non-blocking (graceful degradation on fresh installs before the plugin is cached).

## Files changed
- `plugins/qwickapps-sop/hooks/hooks.json`: SessionStart → session-start.sh
- `plugins/sdlc/hooks/hooks.json`: SessionStart → session-start.sh, PreToolUse/Bash → pre-commit-check.sh
- `plugins/secrets/hooks/hooks.json`: SessionStart → session-start.sh, PreToolUse/Bash → pre-commit-guard.sh
- `plugins/ux-design/hooks/hooks.json`: PreToolUse Edit/Write/MultiEdit → enforce-framework-usage.sh

## Tests
All four `hooks.json` files pass `python3 -m json.tool` validation. No test suite for hooks — runtime behavior verified against local cache structure (`~/.claude/plugins/cache/qwickapps-plugins/`).

## Deviations from plan
None.

## Follow-ups (filed separately)
None.