### PR TITLE
feat: add sentinel to plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,6 +47,12 @@
       "description": "QwickApps Standard Operating Procedures. Optional plugin that configures SDLC skills to use QwickApps MCP tools (Confluence, Projects API, Secrets API) for knowledge base, issue context, sprint management, and worktree-driven development.",
       "source": "./plugins/qwickapps-sop",
       "category": "development"
+    },
+    {
+      "name": "sentinel",
+      "description": "Sentinel — autonomous agent enforcement layer for Claude Code. Classifies tool calls, enforces SOP rules, records session context, and escalates blocked agents. Install once; enforces across all sessions.",
+      "source": "./plugins/sentinel",
+      "category": "devops"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # QwickApps Claude Code Plugins
 
-Official plugin marketplace for QwickApps development with Claude Code. Six plugins covering the full development lifecycle: SDLC discipline, tech stack guidance, UX design enforcement, cloud infrastructure, deployment automation, and secrets management.
+Official plugin marketplace for QwickApps development with Claude Code. Seven plugins covering the full development lifecycle: SDLC discipline, tech stack guidance, UX design enforcement, cloud infrastructure, deployment automation, secrets management, and autonomous agent enforcement.
 
 ## What's New
+
+**June 2026**
+- **sentinel** plugin: autonomous agent enforcement layer — classifies tool calls, enforces SOP rules, records sessions, escalates blocked agents
 
 **March 2026**
 - **secrets** plugin: `github-infra` subcommand for infrastructure-level secrets, env-level naming fixes
@@ -27,6 +30,7 @@ Official plugin marketplace for QwickApps development with Claude Code. Six plug
 /plugins install cloud          # Oracle Cloud infrastructure provisioning
 /plugins install deploy         # CapRover deployment automation
 /plugins install secrets        # Encrypted environment variables
+/plugins install sentinel       # Autonomous agent enforcement
 ```
 
 ## Plugins
@@ -150,12 +154,35 @@ Encrypted environment variable management with SOPS+age. Single `environments.ym
 
 **Hooks**: session-start (detects environments.yml and loads context), pre-commit-guard (blocks unencrypted secret files)
 
+---
+
+### sentinel
+
+Autonomous agent enforcement layer for Claude Code. Every tool call is classified, checked against SOP rules, and either approved, blocked, or redirected before Claude acts.
+
+**Hooks** (6):
+
+| Event | Hook | Purpose |
+|-------|------|---------|
+| `PreToolUse (Bash)` | `bash-intercept.sh` | Classify + oracle + AI safety check |
+| `PreToolUse (.*)` | `tool-recorder.sh` | Session recording |
+| `PostToolUse (.*)` | `tool-outcome.sh` | Async outcome logging |
+| `Stop` | `hook-router.sh Stop` | Escalate-dont-stall |
+| `PreCompact` | `hook-router.sh PreCompact` | Session snapshot + brain flush |
+| `SessionEnd` | `hook-router.sh SessionEnd` | Session snapshot + brain flush |
+
+**Config** (after `install.sh`): `~/.qwickapps/sentinel/sop-rules.yaml` — rule set evaluated by oracle on every intercepted command. Project-local overrides: `.sentinel/sop-rules.yaml`.
+
+**Standalone install**: `bash ~/.sentinel-src/install.sh` — wires hooks into `.claude/settings.json` without requiring the plugin system.
+
+---
+
 ## Repository Structure
 
 ```
 claude-plugins/
   .claude-plugin/
-    marketplace.json          # Marketplace registry (6 plugins)
+    marketplace.json          # Marketplace registry (7 plugins)
   plugins/
     sdlc/                     # SDLC workflows and discipline
       commands/               # 9 slash commands
@@ -187,6 +214,8 @@ claude-plugins/
       hooks/                  # Session start + pre-commit guard
       scripts/                # Sync and encryption utilities
       templates/              # Example config files
+    sentinel/                 # Autonomous agent enforcement
+      hooks/                  # bash-intercept, tool-recorder, tool-outcome, hook-router, session-start
 ```
 
 ## How the Plugins Work Together
@@ -197,5 +226,6 @@ claude-plugins/
 4. **Provision infrastructure** with `cloud` for Oracle Cloud free-tier VMs and services
 5. **Deploy** with `deploy` to generate GitHub Actions workflows and manage CapRover apps
 6. **Manage secrets** with `secrets` to keep environment variables encrypted and in sync
+7. **Enforce discipline** with `sentinel` to block SOP violations at the tool-call level before they reach Claude
 
-The SDLC plugin provides the process. The dev guide provides the architecture. The UX design plugin provides the guardrails. The cloud, deploy, and secrets plugins handle infrastructure and operations.
+The SDLC plugin provides the process. The dev guide provides the architecture. The UX design plugin provides the guardrails. The cloud, deploy, and secrets plugins handle infrastructure and operations. Sentinel enforces safety across all sessions by intercepting tool calls before they execute.

--- a/plugins/sentinel/.claude-plugin/plugin.json
+++ b/plugins/sentinel/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "sentinel",
+  "version": "1.0.0",
+  "description": "Auto-Approval Layer (AAL) for Claude Code agents. Classifies Bash tool calls by intent, enforces SOP rules via oracle, and falls back to AI safety checks for uncovered commands. Installs bash-intercept, tool-recorder, and tool-outcome hooks on first run.",
+  "author": {
+    "name": "QwickApps",
+    "email": "support@qwickapps.com"
+  },
+  "keywords": [
+    "sentinel",
+    "aal",
+    "auto-approval",
+    "bash-intercept",
+    "intent-classifier",
+    "oracle",
+    "sop-rules",
+    "safety"
+  ]
+}

--- a/plugins/sentinel/.claude-plugin/plugin.json
+++ b/plugins/sentinel/.claude-plugin/plugin.json
@@ -1,19 +1,19 @@
 {
   "name": "sentinel",
   "version": "1.0.0",
-  "description": "Auto-Approval Layer (AAL) for Claude Code agents. Classifies Bash tool calls by intent, enforces SOP rules via oracle, and falls back to AI safety checks for uncovered commands. Installs bash-intercept, tool-recorder, and tool-outcome hooks on first run.",
+  "description": "Sentinel — autonomous agent enforcement layer for Claude Code. Classifies tool calls, enforces SOP rules, records session context, and escalates blocked agents. Provides bash-intercept, tool-recorder, tool-outcome, hook-router, and oracle.",
   "author": {
     "name": "QwickApps",
     "email": "support@qwickapps.com"
   },
   "keywords": [
     "sentinel",
-    "aal",
-    "auto-approval",
-    "bash-intercept",
-    "intent-classifier",
-    "oracle",
-    "sop-rules",
-    "safety"
+    "sop",
+    "hooks",
+    "enforcement",
+    "autonomous-agent",
+    "tool-intercept",
+    "session-recording",
+    "oracle"
   ]
 }

--- a/plugins/sentinel/hooks/bash-intercept.sh
+++ b/plugins/sentinel/hooks/bash-intercept.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+# hooks/bash-intercept.sh
+#
+# PreToolUse hook for Claude Code.
+#
+# 1. Evaluates the command using oracle verdicts.
+# 2. Keeps short-lived one-time approval tokens for sensitive operations.
+# 3. For generic policy violations, prompts use of BashWithReason.
+#
+# Exit codes:
+#   0  allow the tool call to proceed
+#   1  blocked with legacy error code
+#   2  blocked and message printed (used by existing Sentinel flow)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${SENTINEL_HOME+x}" ]]; then
+  SENTINEL_HOME="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  SENTINEL_HOME="${SENTINEL_HOME:-${HOME}/.qwickapps/sentinel}"
+fi
+export SENTINEL_HOME
+APPROVALS_DIR="${SENTINEL_HOME}/approvals"
+TOKEN_TTL_SECONDS=300
+
+# ---------------------------------------------------------------------------
+# Read and normalize payload.
+# ---------------------------------------------------------------------------
+
+input="$(cat)"
+
+extract_json_field() {
+  local field="$1"
+  local json="$2"
+  printf '%s' "$json" \
+    | grep -o '"'${field}'"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 \
+    | sed "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\(.*\)\".*/\1/" \
+    || true
+}
+
+extract_command() {
+  printf '%s' "$input" \
+    | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 \
+    | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/' \
+    || true
+}
+
+tool_name="$(extract_json_field "tool_name" "$input")"
+command_str="$(extract_command)"
+
+if [[ "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+
+if [[ -z "$command_str" ]]; then
+  printf 'Use BashWithReason("missing command", "<cmd>") instead.\n'
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Merge-reject guardrail: block direct `gh pr merge` from worker roles.
+# Workers (coder, tester, ops, worker) must report readiness via
+# report("TASK DONE: ready to merge PR #N") instead of merging directly.
+# Also validates that the target PR exists and is open.
+# NOTE: guardrail is called AFTER trust-token checks (line ~370) so that
+# trusted sessions (leads without CLAUDE_ROLE set) can still merge.
+# ---------------------------------------------------------------------------
+
+detect_current_role() {
+  local role=""
+  if [[ -n "${CLAUDE_ROLE:-}" ]]; then
+    role="$CLAUDE_ROLE"
+  elif [[ -n "${SENTINEL_ROLE:-}" ]]; then
+    role="$SENTINEL_ROLE"
+  fi
+  printf '%s' "${role:-worker}"
+}
+
+is_worker_role() {
+  local role="$1"
+  case "$role" in
+    coder|tester|ops|worker|reviewer) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+check_merge_guardrail() {
+  local cmd="$1"
+
+  # Only intercept gh pr merge commands
+  case "$cmd" in
+    *"gh pr merge"*) ;;
+    *) return 0 ;;
+  esac
+
+  local role
+  role="$(detect_current_role)"
+
+  # Block worker roles from direct merges
+  if is_worker_role "$role"; then
+    printf 'MERGE GUARDRAIL: role "%s" cannot merge PRs directly.\n' "$role"
+    printf 'Use: report "TASK DONE: ready to merge PR #N — <summary>"\n'
+    printf 'The manager/sentinel will handle the merge after review.\n'
+    exit 2
+  fi
+
+  # For non-worker roles: validate the PR number exists and is open
+  local pr_num=""
+  pr_num="$(printf '%s' "$cmd" | grep -o -- '--squash\|--merge\|--rebase\|[0-9]\+' | grep -o '[0-9]\+' | head -1 || true)"
+  if [[ -n "$pr_num" ]]; then
+    local repo_flag=""
+    repo_flag="$(printf '%s' "$cmd" | grep -o -- '-R [^ ]*\|--repo [^ ]*' | head -1 || true)"
+    local repo=""
+    repo="$(printf '%s' "$repo_flag" | sed 's/-R //;s/--repo //' | tr -d '"' || true)"
+
+    local pr_state=""
+    if [[ -n "$repo" ]]; then
+      pr_state="$(gh pr view "$pr_num" --repo "$repo" --json state -q '.state' 2>/dev/null || true)"
+    else
+      pr_state="$(gh pr view "$pr_num" --json state -q '.state' 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$pr_state" ]]; then
+      printf 'MERGE GUARDRAIL: PR #%s not found or no GitHub access.\n' "$pr_num"
+      printf 'Verify the PR exists before merging.\n'
+      exit 2
+    fi
+
+    if [[ "$pr_state" != "OPEN" ]]; then
+      printf 'MERGE GUARDRAIL: PR #%s is %s (not OPEN) — cannot merge.\n' "$pr_num" "$pr_state"
+      exit 2
+    fi
+  fi
+
+  return 0
+}
+
+now_epoch() { date +%s; }
+
+hash_command() {
+  local value="$1"
+  local hash=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    hash="$(printf '%s' "$value" | sha256sum | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    hash="$(printf '%s' "$value" | shasum -a 256 | awk '{print $1}')"
+  else
+    hash="$(printf '%s' "$value" | awk '{print length, $0}')"
+  fi
+  printf '%s' "$hash"
+}
+
+command_hash() {
+  printf '%s' "$(hash_command "$1")"
+}
+
+COMMAND_HASH="$(command_hash "$command_str")"
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/\"/\\\"/g'
+}
+
+extract_oracle_field() {
+  local field="$1"
+  local json="$2"
+  printf '%s' "$json" \
+    | grep -o '"'${field}'"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 \
+    | sed "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/" \
+    || true
+}
+
+log_approval_event() {
+  local label="$1"
+  local detail="$2"
+  local log_dir="${SENTINEL_HOME}/logs"
+  mkdir -p "$log_dir" 2>/dev/null || true
+  printf '[%s] %s (%s): %s\n' \
+    "$(date -u +\"%Y-%m-%dT%H:%M:%SZ\")" "$label" "$detail" "$command_str" \
+    >> "${log_dir}/trusted.log"
+}
+
+is_token_valid() {
+  local token_file="$1"
+  local now="$2"
+
+  [[ -f "$token_file" ]] || return 1
+
+  local expires=""
+  expires="$(head -1 "$token_file" | tr -d '[:space:]')"
+  if [[ "$expires" =~ ^[0-9]+$ ]] && (( now < expires )); then
+    return 0
+  fi
+
+  return 1
+}
+
+consume_approval_token() {
+  local token_file="$1"
+  local now="$2"
+
+  if is_token_valid "$token_file" "$now"; then
+    rm -f "$token_file" || true
+    return 0
+  fi
+
+  # Remove stale token so stale entries don't accumulate.
+  rm -f "$token_file" 2>/dev/null || true
+  return 1
+}
+
+lookup_oracle() {
+  local oracle_bin="$1"
+  local classify_bin="$2"
+  local reason="$3"
+  local cmd="$4"
+
+  local op_class=""
+  local oracle_input=""
+  local raw_result=""
+  local verdict="approve"
+  local guidance=""
+  local redirect=""
+
+  if [[ -x "$classify_bin" ]]; then
+    op_class="$(printf '{"reason":"%s","command":"%s"}' \
+      "$(json_escape "$reason")" "$(json_escape "$cmd")" \
+      | "$classify_bin" 2>/dev/null \
+      | extract_oracle_field "op_class" || true)"
+  fi
+
+  if [[ -z "$op_class" ]]; then
+    op_class="UnknownOp"
+  fi
+
+  if [[ -x "$oracle_bin" ]]; then
+    oracle_input="$(printf '{"op_class":"%s","reason":"%s","command":"%s"}' \
+      "$(json_escape "$op_class")" "$(json_escape "$reason")" "$(json_escape "$cmd")")"
+    raw_result="$(printf '%s' "$oracle_input" | "$oracle_bin" 2>/dev/null || true)"
+    if [[ -n "$raw_result" ]]; then
+      verdict="$(extract_oracle_field "verdict" "$raw_result")"
+      guidance="$(extract_oracle_field "guidance" "$raw_result")"
+      redirect="$(extract_oracle_field "tool_redirect" "$raw_result")"
+      [[ -z "$verdict" ]] && verdict="approve"
+    fi
+  fi
+
+  printf '%s\t%s\t%s\t%s\n' "$verdict" "$guidance" "$redirect" "$op_class"
+}
+
+send_telegram() {
+  local message="$1"
+
+  if command -v mcp >/dev/null 2>&1; then
+    mcp call mcp__qwickapps__send_telegram --message "$message" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  if command -v mcp__qwickapps__send_telegram >/dev/null 2>&1; then
+    mcp__qwickapps__send_telegram --message "$message" >/dev/null 2>&1 || true
+    mcp__qwickapps__send_telegram "$message" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  return 1
+}
+
+challenge_code_for_command() {
+  local challenge_file="$1"
+  local now="$2"
+
+  mkdir -p "$APPROVALS_DIR"
+
+  if [[ -f "$challenge_file" ]]; then
+    local saved_code saved_at
+    saved_code="$(sed -n '1p' "$challenge_file" | tr -d '[:space:]')"
+    saved_at="$(sed -n '2p' "$challenge_file" | tr -d '[:space:]')"
+
+    if [[ "$saved_code" =~ ^[0-9A-F]{4}$ && "$saved_at" =~ ^[0-9]+$ ]]; then
+      if (( now - saved_at <= TOKEN_TTL_SECONDS )); then
+        printf '%s' "$saved_code"
+        return 0
+      fi
+      rm -f "$challenge_file"
+    else
+      rm -f "$challenge_file"
+    fi
+  fi
+
+  local new_code=""
+  new_code="$(od -An -N2 -tx2 /dev/urandom 2>/dev/null | tr -dc 'A-F0-9' | tr '[:lower:]' '[:upper:]' | head -c 4)"
+  [[ ${#new_code} -lt 4 ]] && new_code="$(date +%s | tail -c 5)"
+
+  printf '%s\n%s\n' "$new_code" "$now" > "$challenge_file"
+  printf '%s' "$new_code"
+}
+
+# ---------------------------------------------------------------------------
+# 1) Single-use approval token check first (high-priority bypass for AAL).
+# ---------------------------------------------------------------------------
+
+mkdir -p "$APPROVALS_DIR" 2>/dev/null || true
+TOKEN_FILE="${APPROVALS_DIR}/${COMMAND_HASH}.token"
+NOW_TS="$(now_epoch)"
+
+if consume_approval_token "$TOKEN_FILE" "$NOW_TS"; then
+  log_approval_event "approved" "single_use_token hash=${COMMAND_HASH}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2) Oracle verdict lookup.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ORACLE_BIN="${SCRIPT_DIR}/oracle.sh"
+CLASSIFY_BIN="${SCRIPT_DIR}/classify.sh"
+
+read -r ORACLE_VERDICT ORACLE_GUIDANCE ORACLE_TOOL_REDIRECT ORACLE_OP_CLASS <<< "$(lookup_oracle \"$ORACLE_BIN\" \"$CLASSIFY_BIN\" \"Bash command intercepted\" \"$command_str\")"
+[[ -z "$ORACLE_VERDICT" ]] && ORACLE_VERDICT="approve"
+
+# ---------------------------------------------------------------------------
+# 3) approval_required => challenge + telegram block.
+# ---------------------------------------------------------------------------
+
+if [[ "$ORACLE_VERDICT" == "approval_required" ]]; then
+  CHALLENGE_FILE="${APPROVALS_DIR}/${COMMAND_HASH}.challenge"
+  CHALLENGE_CODE="$(challenge_code_for_command "$CHALLENGE_FILE" "$NOW_TS")"
+
+  BLOCK_MESSAGE="Approval required for Bash operation. Challenge code: ${CHALLENGE_CODE} — reply with your Authify TOTP + this code to proceed."
+  TELEGRAM_MESSAGE="${BLOCK_MESSAGE} (command hash: ${COMMAND_HASH}, op: ${ORACLE_OP_CLASS:-UnknownOp})"
+
+  send_telegram "$TELEGRAM_MESSAGE" || true
+
+  printf '%s\n' "$BLOCK_MESSAGE"
+  log_approval_event "approval_required" "hash=${COMMAND_HASH} challenge=${CHALLENGE_CODE}"
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# 4) Legacy trust-token flow remains for non-sensitive approvals.
+# ---------------------------------------------------------------------------
+
+# Resolve session ID
+if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+  _raw_session="$CLAUDE_SESSION_ID"
+elif [[ -n "${TMUX_PANE:-}" ]]; then
+  _raw_session="$TMUX_PANE"
+else
+  _raw_session="default"
+fi
+
+_safe_session="${_raw_session//[\/: ]/_}"
+_safe_session="$(printf '%s' "$_safe_session" | tr '[:space:]' '_')"
+TOKEN_PATH="${SENTINEL_HOME}/trust-tokens/${_safe_session}"
+
+if [[ -f "$TOKEN_PATH" ]]; then
+  token_expiry="$(head -1 "$TOKEN_PATH" | tr -d '[:space:]')"
+  if [[ "$token_expiry" =~ ^[0-9]+$ ]] && (( NOW_TS < token_expiry )); then
+    log_approval_event "trusted-session" "session=${_raw_session} expires=${token_expiry}"
+    exit 0
+  fi
+fi
+
+if [[ -n "${AAL_TRUSTED_SESSION:-}" ]] && [[ "$AAL_TRUSTED_SESSION" =~ ^[0-9]+$ ]] && (( NOW_TS < AAL_TRUSTED_SESSION )); then
+  log_approval_event "trusted-session" "expires=${AAL_TRUSTED_SESSION}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4b) Merge-reject guardrail (after trust-token checks so leads with no
+#     CLAUDE_ROLE in env can still merge via a trust token).
+# ---------------------------------------------------------------------------
+
+check_merge_guardrail "$command_str"
+
+# ---------------------------------------------------------------------------
+# 4c) CapRover/Coolify live-app write guard.
+#
+# Blocks two categories of dangerous raw API writes:
+#   1. Any POST/PUT/PATCH/DELETE to /api/v*/ against a *-live app — agents
+#      must use the blue-green CI deploy pipeline, not direct production edits.
+#   2. Any appDefinitions/update call missing the full envVars array — the
+#      Coolify envVars-clearing bug silently wipes all env vars when omitted.
+#
+# Bypass: valid single-use approval token (section 1) or session trust token
+# (section 4) — for genuine emergency manual operations only.
+# ---------------------------------------------------------------------------
+
+check_caprover_live_guard() {
+  local cmd="$1"
+
+  # Only intercept HTTP client commands
+  case "$cmd" in
+    *curl*|*wget*) ;;
+    *) return 0 ;;
+  esac
+
+  # Detect write HTTP methods
+  local is_write=0
+  # Explicit -X POST / -XPOST / --request POST (case-insensitive)
+  if printf '%s' "$cmd" | grep -qiE '(-X[[:space:]]*(POST|PUT|PATCH|DELETE)|--request[[:space:]]+(POST|PUT|PATCH|DELETE))'; then
+    is_write=1
+  fi
+  # Implicit POST: -d / --data present without an explicit -X GET
+  if printf '%s' "$cmd" | grep -qE '( -d | --data[ =])' && \
+     ! printf '%s' "$cmd" | grep -qiE '(-X[[:space:]]*GET|--request[[:space:]]+GET)'; then
+    is_write=1
+  fi
+  # wget --post-data / --post-file
+  case "$cmd" in
+    *"--post-data"*|*"--post-file"*) is_write=1 ;;
+  esac
+
+  [[ $is_write -eq 0 ]] && return 0
+
+  # Only act on CapRover/Coolify API paths (/api/v1/, /api/v2/, …)
+  if ! printf '%s' "$cmd" | grep -qE '/api/v[0-9]+/'; then
+    return 0
+  fi
+
+  # Guard 1: Block writes against *-live app identifiers in the URL/body
+  if printf '%s' "$cmd" | grep -qE '[a-z0-9]+-live([^a-z0-9]|$)'; then
+    printf 'CAPROVER LIVE GUARD: direct API writes to *-live apps are blocked.\n'
+    printf 'Use the blue-green CI deploy pipeline, not a raw production edit.\n'
+    printf 'See: Blue-Green Deployment SOP (KB docs 68648962 / 68485124)\n'
+    exit 2
+  fi
+
+  # Guard 2: Block appDefinitions/update without the full envVars array
+  if printf '%s' "$cmd" | grep -q 'appDefinitions/update'; then
+    local has_env_vars=0
+    printf '%s' "$cmd" | grep -q 'envVars' && has_env_vars=1
+    # Also check body from @file reference
+    if [[ $has_env_vars -eq 0 ]]; then
+      local data_file
+      data_file="$(printf '%s' "$cmd" | grep -oE '@[^[:space:]]+' | head -1 | sed 's/^@//' || true)"
+      if [[ -n "$data_file" && -f "$data_file" ]]; then
+        grep -q 'envVars' "$data_file" 2>/dev/null && has_env_vars=1
+      fi
+    fi
+    if [[ $has_env_vars -eq 0 ]]; then
+      printf 'CAPROVER ENV GUARD: appDefinitions/update without envVars array.\n'
+      printf 'Omitting envVars silently wipes ALL environment variables.\n'
+      printf 'Always include the complete envVars array in every appDefinitions/update call.\n'
+      exit 2
+    fi
+  fi
+
+  return 0
+}
+
+check_caprover_live_guard "$command_str"
+
+# ---------------------------------------------------------------------------
+# 5) Block with context when oracle asked for review.
+# ---------------------------------------------------------------------------
+
+case "$ORACLE_VERDICT" in
+  approve)
+    exit 0
+    ;;
+  reject)
+    if [[ -n "$ORACLE_GUIDANCE" ]]; then
+      printf 'Oracle rejected command: %s\n' "$ORACLE_GUIDANCE"
+    else
+      printf 'Oracle rejected command. Use BashWithReason to review.\n'
+    fi
+    ;;
+  redirect)
+    if [[ -n "$ORACLE_TOOL_REDIRECT" ]]; then
+      printf 'Oracle redirect: use %s. %s\n' "$ORACLE_TOOL_REDIRECT" "${ORACLE_GUIDANCE}"
+    else
+      printf '%s\n' "${ORACLE_GUIDANCE:-Oracle requested redirect; use BashWithReason instead.}"
+    fi
+    ;;
+  *)
+    if [[ -n "$ORACLE_GUIDANCE" ]]; then
+      printf '%s\n' "$ORACLE_GUIDANCE"
+    else
+      printf 'Use BashWithReason("%s", "%s") instead.\n' "Oracle check" "$(printf '%s' "$command_str" | head -c 120 | sed 's/%/%%/g')"
+    fi
+    ;;
+esac
+
+exit 2

--- a/plugins/sentinel/hooks/hook-router.sh
+++ b/plugins/sentinel/hooks/hook-router.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# Centralized lifecycle-hook router
+#
+# Dispatches Claude Code lifecycle events to registered handlers.
+# Reads event type + payload from stdin, routes to the appropriate handler,
+# and returns the correct output shape per event (additionalContext for injection,
+# allow/block for intercepts, exit 0 for fire-and-forget).
+#
+# Usage:
+#   echo '{"event": "SessionStart", ...}' | hook-router.sh <event>
+#   or via Claude Code settings.json hooks configuration
+#
+# Design: fail-safe (handler errors never break a session), bash 3.2 safe,
+# role-aware via detect-role.sh.
+#
+# SessionStart: merges inject-protocol (role protocol) + brain-inject (brain index)
+#   into a single additionalContext response.
+# PreCompact/SessionEnd: runs session-snapshot (local log) + brain-compile
+#   (flush learnings to brain vault, fire-and-forget).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SENTINEL_HOME="${SENTINEL_HOME:-${HOME}/.qwickapps/sentinel}"
+HANDLERS_DIR="${SCRIPT_DIR}/handlers"
+BRAIN_DIR="${HOME}/.qwickapps/brain"
+LOG_FILE="${SENTINEL_HOME}/logs/hooks.log"
+
+# Events we handle
+EVENT="${1:-}"
+
+if [[ -z "$EVENT" ]]; then
+  printf 'ERROR: event type required\n' >&2
+  exit 1
+fi
+
+# Create log directory if needed
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+# Read payload from stdin
+payload=""
+if [[ -t 0 ]]; then
+  payload="{}"
+else
+  payload="$(cat)"
+fi
+
+# ---------------------------------------------------------------------------
+# Fail-safe single-handler runner
+# ---------------------------------------------------------------------------
+
+run_handler_safe() {
+  local handler_name="$1"
+  local handler_path="${HANDLERS_DIR}/${handler_name}.sh"
+
+  if [[ ! -x "$handler_path" ]]; then
+    printf '[WARN] Hook handler not found: %s\n' "$handler_path" >&2
+    printf '[%s] %s: handler not found\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$EVENT" >> "$LOG_FILE" 2>/dev/null || true
+    return 0
+  fi
+
+  local output=""
+  output=$(bash "$handler_path" <<< "$payload" 2>&1) || true
+
+  printf '[%s] %s: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$EVENT" "$handler_name" >> "$LOG_FILE" 2>/dev/null || true
+
+  printf '%s\n' "$output"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# SessionStart: merge inject-protocol + brain-inject into one additionalContext
+# ---------------------------------------------------------------------------
+
+run_session_start() {
+  local handler_path="${HANDLERS_DIR}/inject-protocol.sh"
+  local brain_inject="${BRAIN_DIR}/scripts/brain-inject.sh"
+
+  local protocol_text=""
+  local brain_text=""
+
+  # Get role protocol (inject-protocol outputs {"additionalContext": "...", "metadata": {...}})
+  if [[ -x "$handler_path" ]]; then
+    local proto_out
+    proto_out=$(bash "$handler_path" <<< "$payload" 2>/dev/null || true)
+    if command -v jq &>/dev/null && [[ -n "$proto_out" ]]; then
+      protocol_text=$(jq -r '.additionalContext // empty' <<< "$proto_out" 2>/dev/null || true)
+    fi
+    # Fallback: treat whole output as text
+    if [[ -z "$protocol_text" ]]; then
+      protocol_text="$proto_out"
+    fi
+  fi
+
+  # Get brain index (brain-inject outputs {"context": "...", "role": "..."})
+  if [[ -f "$brain_inject" ]]; then
+    local brain_out
+    brain_out=$(bash "$brain_inject" 2>/dev/null || true)
+    if command -v jq &>/dev/null && [[ -n "$brain_out" ]]; then
+      brain_text=$(jq -r '.context // empty' <<< "$brain_out" 2>/dev/null || true)
+    fi
+    # Fallback: treat whole output as text
+    if [[ -z "$brain_text" ]]; then
+      brain_text="$brain_out"
+    fi
+  fi
+
+  # Merge both into single additionalContext
+  local combined=""
+  if [[ -n "$protocol_text" && -n "$brain_text" ]]; then
+    combined="${protocol_text}
+
+---
+
+${brain_text}"
+  elif [[ -n "$protocol_text" ]]; then
+    combined="$protocol_text"
+  elif [[ -n "$brain_text" ]]; then
+    combined="$brain_text"
+  fi
+
+  # Emit in the SessionStart hook output shape Claude Code actually reads:
+  # hookSpecificOutput.additionalContext. The previous top-level {"additionalContext"}
+  # form was silently ignored, so NO agent ever received its injected protocol.
+  if [[ -n "$combined" ]]; then
+    if command -v jq &>/dev/null; then
+      jq -n --arg ctx "$combined" \
+        '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+    else
+      python3 -c "
+import json, sys
+ctx = sys.stdin.read()
+print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', 'additionalContext': ctx}}))
+" <<< "$combined" 2>/dev/null || true
+    fi
+  fi
+
+  printf '[%s] SessionStart: inject-protocol+brain merged (proto=%s brain=%s)\n' \
+    "$(date '+%Y-%m-%d %H:%M:%S')" \
+    "$([ -n "$protocol_text" ] && echo yes || echo no)" \
+    "$([ -n "$brain_text" ] && echo yes || echo no)" \
+    >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Stop: behavior-monitor (sync, may block) → escalate-dont-stall → decision-discipline
+# ---------------------------------------------------------------------------
+
+run_stop() {
+  local bm_out=""
+  bm_out="$(bash "${HANDLERS_DIR}/behavior-monitor.sh" <<< "$payload" 2>/dev/null || true)"
+  if [[ -n "$bm_out" ]]; then
+    printf '%s\n' "$bm_out"
+    printf '[%s] Stop: behavior-monitor blocked\n' \
+      "$(date '+%Y-%m-%d %H:%M:%S')" >> "$LOG_FILE" 2>/dev/null || true
+    exit 0
+  fi
+  printf '[%s] Stop: behavior-monitor clean\n' \
+    "$(date '+%Y-%m-%d %H:%M:%S')" >> "$LOG_FILE" 2>/dev/null || true
+  run_handler_safe "escalate-dont-stall"
+  run_handler_safe "decision-discipline-guard"
+}
+
+# ---------------------------------------------------------------------------
+# PreCompact / SessionEnd: session-snapshot + brain-compile (both fire-and-forget)
+# ---------------------------------------------------------------------------
+
+run_compaction() {
+  # 1. Local session snapshot (log to ~/.qwickapps/sentinel/logs/)
+  run_handler_safe "session-snapshot"
+
+  # 2. Brain flush: extract learnings → write to brain vault
+  #    brain-compile.sh calls flush.py which forks immediately — returns fast
+  local brain_compile="${BRAIN_DIR}/scripts/brain-compile.sh"
+  if [[ -f "$brain_compile" ]]; then
+    bash "$brain_compile" <<< "$payload" 2>/dev/null || true
+    printf '[%s] %s: brain-compile fired\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$EVENT" >> "$LOG_FILE" 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Route to handler based on event type
+# ---------------------------------------------------------------------------
+
+case "$EVENT" in
+  SessionStart)
+    run_session_start
+    ;;
+  UserPromptSubmit)
+    # Optional: context injection (future)
+    exit 0
+    ;;
+  PreToolUse)
+    run_handler_safe "bash-intercept"
+    ;;
+  Stop)
+    run_stop
+    ;;
+  PreCompact|SessionEnd)
+    run_compaction
+    ;;
+  *)
+    printf 'WARN: unknown event: %s\n' "$EVENT" >&2
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/plugins/sentinel/hooks/hooks.json
+++ b/plugins/sentinel/hooks/hooks.json
@@ -1,0 +1,47 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/install.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" --cron 2>/dev/null || exit 0'",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[ -x ~/.qwickapps/sentinel/bin/tool-recorder.sh ] && bash ~/.qwickapps/sentinel/bin/tool-recorder.sh || exit 0'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[ -x ~/.qwickapps/sentinel/bin/bash-intercept.sh ] && bash ~/.qwickapps/sentinel/bin/bash-intercept.sh || exit 0'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[ -x ~/.qwickapps/sentinel/bin/tool-outcome.sh ] && bash ~/.qwickapps/sentinel/bin/tool-outcome.sh || exit 0'",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/sentinel/hooks/hooks.json
+++ b/plugins/sentinel/hooks/hooks.json
@@ -5,28 +5,28 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/install.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" --cron 2>/dev/null || exit 0'",
-            "async": true
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/hooks/session-start.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'",
+            "async": false
           }
         ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c '[ -x ~/.qwickapps/sentinel/bin/tool-recorder.sh ] && bash ~/.qwickapps/sentinel/bin/tool-recorder.sh || exit 0'"
-          }
-        ]
-      },
-      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c '[ -x ~/.qwickapps/sentinel/bin/bash-intercept.sh ] && bash ~/.qwickapps/sentinel/bin/bash-intercept.sh || exit 0'"
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/hooks/bash-intercept.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'"
+          }
+        ]
+      },
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/hooks/tool-recorder.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'"
           }
         ]
       }
@@ -37,7 +37,43 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c '[ -x ~/.qwickapps/sentinel/bin/tool-outcome.sh ] && bash ~/.qwickapps/sentinel/bin/tool-outcome.sh || exit 0'",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/hooks/tool-outcome.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" || exit 0'",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/hooks/hook-router.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" Stop || exit 0'",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/hooks/hook-router.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" PreCompact || exit 0'",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'f=$(ls ~/.claude/plugins/cache/qwickapps-plugins/sentinel/*/hooks/hook-router.sh 2>/dev/null | sort -V | tail -1); [ -n \"$f\" ] && bash \"$f\" SessionEnd || exit 0'",
             "async": true
           }
         ]

--- a/plugins/sentinel/hooks/session-start.sh
+++ b/plugins/sentinel/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SessionStart hook for sentinel plugin
+# Injects sentinel context — confirms enforcement is active and
+# summarises the classify -> oracle -> AI pipeline.
+
+set -euo pipefail
+
+session_context="<IMPORTANT>\nSentinel is active.\n\nSentinel intercepts every tool call, classifies intent (classify.sh), and enforces SOP rules (oracle.sh). Any operation that violates sop-rules.yaml is blocked or redirected before it reaches Claude.\n\nHooks wired:\n  PreToolUse  (Bash)  -> bash-intercept.sh  (classify + oracle + AI check)\n  PreToolUse  (.*)    -> tool-recorder.sh   (session recording)\n  PostToolUse (.*)    -> tool-outcome.sh    (async outcome logging)\n  Stop        (.*)    -> hook-router.sh Stop         (escalate-dont-stall)\n  PreCompact  (.*)    -> hook-router.sh PreCompact   (session snapshot + brain flush)\n  SessionEnd  (.*)    -> hook-router.sh SessionEnd   (session snapshot + brain flush)\n\nConfig: ~/.qwickapps/sentinel/config.yaml\nRules:  ~/.qwickapps/sentinel/sop-rules.yaml (project-local: .sentinel/sop-rules.yaml)\nLogs:   ~/.qwickapps/sentinel/logs/\n\nTo reinstall or update: bash ~/.sentinel-src/install.sh\n</IMPORTANT>"
+
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "${session_context}"
+  }
+}
+EOF
+
+exit 0

--- a/plugins/sentinel/hooks/tool-outcome.sh
+++ b/plugins/sentinel/hooks/tool-outcome.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# hooks/tool-outcome.sh
+#
+# PostToolUse hook (matcher: .*) — audit-log every tool outcome.
+#
+# Appends a compact JSONL record to ~/.qwickapps/sentinel/logs/tool-use.jsonl.
+# Always exits 0 — never blocks.
+#
+# Record format:
+#   {"ts":"ISO8601","event":"post","tool":"ToolName","ok":true}
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${SENTINEL_HOME+x}" ]]; then
+  SENTINEL_HOME="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  SENTINEL_HOME="${SENTINEL_HOME:-${HOME}/.qwickapps/sentinel}"
+fi
+export SENTINEL_HOME
+LOG_FILE="${SENTINEL_HOME}/logs/tool-use.jsonl"
+
+input="$(cat)"
+
+field() {
+  printf '%s' "$input" \
+    | grep -o "\"${1}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+    | head -1 \
+    | sed "s/.*\"${1}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/" \
+    || true
+}
+
+tool="$(field tool_name)"
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+
+escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+ok="true"
+if printf '%s' "$input" | grep -q '"isError"[[:space:]]*:[[:space:]]*true'; then
+  ok="false"
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+printf '{"ts":"%s","event":"post","tool":"%s","ok":%s}\n' \
+  "$ts" "$(escape "$tool")" "$ok" >> "$LOG_FILE" 2>/dev/null || true
+
+exit 0

--- a/plugins/sentinel/hooks/tool-recorder.sh
+++ b/plugins/sentinel/hooks/tool-recorder.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# hooks/tool-recorder.sh
+#
+# PreToolUse hook (matcher: .*) — records every tool invocation to a JSONL session log.
+#
+# Appends one line to $SENTINEL_HOME/sessions/<session_id>.jsonl:
+#   {"ts":"...","tool":"Read","summary":"path=/tmp/foo","session_id":"abc","seq":1}
+#
+# Set SENTINEL_RECORD_TOOLS=0 to disable recording entirely.
+# Never logs file contents, command output, or other sensitive data.
+# Must not block — any failure exits 0 silently.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${SENTINEL_HOME+x}" ]]; then
+  SENTINEL_HOME="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  SENTINEL_HOME="${SENTINEL_HOME:-${HOME}/.qwickapps/sentinel}"
+fi
+export SENTINEL_HOME
+
+if [[ "${SENTINEL_RECORD_TOOLS:-}" == "0" ]]; then
+  exit 0
+fi
+
+input="$(cat 2>/dev/null)" || exit 0
+
+_extract_field() {
+  local field="$1"
+  printf '%s' "$input" | awk -v field="$field" '
+    {
+      regex = "\"" field "\"[[:space:]]*:[[:space:]]*\""
+      if (match($0, regex)) {
+        start = RSTART + RLENGTH
+        value = ""
+        escape = 0
+        for (i = start; i <= length($0); i++) {
+          ch = substr($0, i, 1)
+          if (escape) {
+            value = value ch
+            escape = 0
+            continue
+          }
+          if (ch == "\\") {
+            escape = 1
+            continue
+          }
+          if (ch == "\"") {
+            break
+          }
+          value = value ch
+        }
+        print value
+        exit
+      }
+    }
+  '
+}
+
+tool_name="$(_extract_field "tool_name")"
+[[ -z "$tool_name" ]] && exit 0
+
+if [[ -n "${SENTINEL_SESSION_ID:-}" ]]; then
+  _raw_session="$SENTINEL_SESSION_ID"
+elif [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+  _raw_session="$CLAUDE_SESSION_ID"
+elif [[ -n "${TMUX_PANE:-}" ]]; then
+  _raw_session="$TMUX_PANE"
+else
+  _raw_session="default"
+fi
+
+_safe_session="${_raw_session//[\/: ]/_}"
+_safe_session="$(printf '%s' "$_safe_session" | tr '[:space:]' '_')"
+
+SESSIONS_DIR="${SENTINEL_HOME}/sessions"
+mkdir -p "$SESSIONS_DIR" 2>/dev/null || exit 0
+
+SEQ_FILE="${SESSIONS_DIR}/${_safe_session}.seq"
+JSONL_FILE="${SESSIONS_DIR}/${_safe_session}.jsonl"
+
+_increment_seq() {
+  local seq=0
+  if [[ -f "$SEQ_FILE" ]]; then
+    seq="$(head -1 "$SEQ_FILE" | tr -d '[:space:]')"
+    [[ "$seq" =~ ^[0-9]+$ ]] || seq=0
+  fi
+  seq=$(( seq + 1 ))
+  printf '%d\n' "$seq" > "$SEQ_FILE"
+  printf '%d' "$seq"
+}
+
+if command -v flock >/dev/null 2>&1; then
+  seq="$(flock -x "$SESSIONS_DIR" bash -c "
+    SEQ_FILE='${SEQ_FILE}'
+    seq=0
+    if [[ -f \"\$SEQ_FILE\" ]]; then
+      seq=\"\$(head -1 \"\$SEQ_FILE\" | tr -d '[:space:]')\"
+      [[ \"\$seq\" =~ ^[0-9]+\$ ]] || seq=0
+    fi
+    seq=\$(( seq + 1 ))
+    printf '%d\\n' \"\$seq\" > \"\$SEQ_FILE\"
+    printf '%d' \"\$seq\"
+  " 2>/dev/null)" || seq="$(_increment_seq)"
+else
+  seq="$(_increment_seq)"
+fi
+
+[[ "$seq" =~ ^[0-9]+$ ]] || seq=1
+
+case "$tool_name" in
+  Bash)
+    payload="$(_extract_field "command")"
+    summary="command=${payload:0:60}"
+    ;;
+  Read|Write|Edit)
+    path="$(_extract_field "file_path")"
+    [[ -z "$path" ]] && path="$(_extract_field "path")"
+    summary="path=${path}"
+    ;;
+  WebFetch)
+    summary="url=$(_extract_field "url")"
+    ;;
+  WebSearch)
+    url="$(_extract_field "query")"
+    [[ -z "$url" ]] && url="$(_extract_field "url")"
+    summary="url=${url}"
+    ;;
+  *)
+    summary="tool=${tool_name}"
+    ;;
+esac
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+
+escape() {
+  printf '%s' "$1" \
+    | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\r/\\r/g; s/\n/\\n/g'
+}
+
+printf '{"ts":"%s","tool":"%s","summary":"%s","session_id":"%s","seq":%d}\n' \
+  "$ts" \
+  "$(escape "$tool_name")" \
+  "$(escape "$summary")" \
+  "$(escape "$_raw_session")" \
+  "$seq" >> "$JSONL_FILE" 2>/dev/null || true
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `sentinel` as an installable entry in the qwickapps-plugins marketplace
- Plugin registers 4 Claude Code hooks that make up the Auto-Approval Layer (AAL)
- First-run bootstrap is async (no session delay); subsequent sessions just call the installed scripts

## Hooks registered

| Event | Matcher | Script | Purpose |
|---|---|---|---|
| SessionStart | - | `install.sh` (async) | Bootstrap `~/.qwickapps/sentinel/` on fresh machine |
| PreToolUse | `.*` | `tool-recorder.sh` | Audit-log every tool call |
| PreToolUse | `Bash` | `bash-intercept.sh` | classify→oracle→AI safety gate |
| PostToolUse | `.*` | `tool-outcome.sh` (async) | Audit-log every tool result |

## Fail-open design

Pre/PostToolUse hooks check `[ -x ~/.qwickapps/sentinel/bin/<script> ]` before calling — if sentinel hasn't bootstrapped yet, they exit 0 (allow). Next session start triggers bootstrap.

## Related

- qwickapps/sentinel#48
- qwickapps/sentinel PR#51 (oracle pipeline + SOP rules — must merge before this ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)